### PR TITLE
Improve simplified Chinese text search result

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -12,6 +12,20 @@ let minisearchInstance: MiniSearch<IndexedNote>
 
 let indexedNotes: Record<string, IndexedNote> = {}
 
+const chsPattern = /[\u4e00-\u9fa5]/
+
+const tokenize = (text: string): string[] => {
+  const tokens = text.split(SPACE_OR_PUNCTUATION)
+  const chsSegmenter = (app as any).plugins.plugins['cm-chs-patch']
+
+  if (chsSegmenter) {
+    return tokens.flatMap(word =>
+      chsPattern.test(word) ? chsSegmenter.cut(word) : [word],
+    )
+  }
+  else return tokens
+}
+
 /**
  * Initializes the MiniSearch instance,
  * and adds all the notes to the index
@@ -19,7 +33,7 @@ let indexedNotes: Record<string, IndexedNote> = {}
 export async function initGlobalSearchIndex(): Promise<void> {
   indexedNotes = {}
   minisearchInstance = new MiniSearch({
-    tokenize: text => text.split(SPACE_OR_PUNCTUATION),
+    tokenize,
     idField: 'path',
     fields: ['basename', 'content', 'headings1', 'headings2', 'headings3'],
   })


### PR DESCRIPTION
In the new tokenize function, it will detect if [another Chinese word segmenter plugin](https://github.com/aidenlx/cm-chs-patch) is enabled or not, and use it to extend tokenize result when there are Chinese characters exist in token text. 

this PR should solve https://github.com/scambier/obsidian-omnisearch/issues/33

in [cm-chs-patch](https://github.com/aidenlx/cm-chs-patch), it has an option to use a wasm segmenter module in favor system segmenter, which [produces terrible index result for some keywords](https://github.com/scambier/obsidian-omnisearch/issues/33#issuecomment-1113650515)