### PR TITLE
Allow VIM navigation shortcuts without VIM mode enabled in Obsidian

### DIFF
--- a/src/components/modals.ts
+++ b/src/components/modals.ts
@@ -38,10 +38,8 @@ abstract class OmnisearchModal extends Modal {
     ] as const) {
       for (const modifier of ['Ctrl', 'Mod'] as const) {
         this.scope.register([modifier], key.k, _e => {
-          if (this.app.vault.getConfig('vimMode')) {
             // e.preventDefault()
             eventBus.emit('arrow-' + key.dir)
-          }
         })
       }
     }
@@ -53,10 +51,8 @@ abstract class OmnisearchModal extends Modal {
     ] as const) {
       for (const modifier of ['Ctrl', 'Mod'] as const) {
         this.scope.register([modifier], key.k, _e => {
-          if (this.app.vault.getConfig('vimMode')) {
             // e.preventDefault()
             eventBus.emit('arrow-' + key.dir)
-          }
         })
       }
     }


### PR DESCRIPTION
close #198