### PR TITLE
Change the order of tokenizing text.

### DIFF
--- a/src/search/omnisearch.ts
+++ b/src/search/omnisearch.ts
@@ -25,6 +25,12 @@ import { sortBy } from 'lodash-es'
 const tokenize = (text: string): string[] => {
   let tokens = text.split(SPACE_OR_PUNCTUATION)
 
+  // Split hyphenated tokens
+  tokens = [...tokens, ...tokens.flatMap(splitHyphens)]
+
+  // Split camelCase tokens into "camel" and "case
+  tokens = [...tokens, ...tokens.flatMap(splitCamelCase)]
+
   // When enabled, we only use the chsSegmenter,
   // and not the other custom tokenizers
   const chsSegmenter = getChsSegmenter()
@@ -32,12 +38,8 @@ const tokenize = (text: string): string[] => {
     tokens = tokens.flatMap(word =>
       chsRegex.test(word) ? chsSegmenter.cut(word) : [word]
     )
-  } else {
-    // Split camelCase tokens into "camel" and "case
-    tokens = [...tokens, ...tokens.flatMap(splitCamelCase)]
-    // Split hyphenated tokens
-    tokens = [...tokens, ...tokens.flatMap(splitHyphens)]
   }
+
   return tokens
 }
 


### PR DESCRIPTION
A Chinese user may also have english notes, but previous implementation can not handle hyphens and camel case. This commit should fix it by changing the order of how tokens are generated

before:
<img width="778" alt="image" src="https://github.com/scambier/obsidian-omnisearch/assets/29861494/106cb8f7-fca5-4565-92df-69cd64d67301">

after:
<img width="685" alt="image" src="https://github.com/scambier/obsidian-omnisearch/assets/29861494/5dce9292-7740-4c08-86ab-acf295da4daa">

___

Also, I found that the setting `splitCamelCase` is always on when indexing notes and only affect note highlighting in function `stringsToRegex`, which seems to be the only reference.

But according to the description

> Enable this if you want to be able to search for CamelCaseWords as separate words.

This doesn't match, am I missing something?