### PR TITLE
Allow VIM navigation shortcuts without VIM mode enabled in Obsidian

### DIFF
--- a/src/components/modals.ts
+++ b/src/components/modals.ts
@@ -38,10 +38,10 @@ abstract class OmnisearchModal extends Modal {
     ] as const) {
       for (const modifier of ['Ctrl', 'Mod'] as const) {
         this.scope.register([modifier], key.k, _e => {
-          if (this.app.vault.getConfig('vimMode')) {
-            // e.preventDefault()
-            eventBus.emit('arrow-' + key.dir)
-          }
+            if (settings.vimLikeNavigationShortcut) {
+              // e.preventDefault()
+              eventBus.emit('arrow-' + key.dir)
+            }
         })
       }
     }
@@ -53,7 +53,7 @@ abstract class OmnisearchModal extends Modal {
     ] as const) {
       for (const modifier of ['Ctrl', 'Mod'] as const) {
         this.scope.register([modifier], key.k, _e => {
-          if (this.app.vault.getConfig('vimMode')) {
+          if (settings.vimLikeNavigationShortcut) {
             // e.preventDefault()
             eventBus.emit('arrow-' + key.dir)
           }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -56,6 +56,7 @@ export interface OmnisearchSettings extends WeightingSettings {
   splitCamelCase: boolean
   openInNewPane: boolean
   verboseLogging: boolean
+  vimLikeNavigationShortcut: boolean
   fuzziness: '0' | '1' | '2'
 }
 
@@ -263,6 +264,7 @@ export class SettingsTab extends PluginSettingTab {
         })
       )
 
+    // Open in new pane
     new Setting(containerEl)
       .setName('Open in new pane')
       .setDesc(
@@ -271,6 +273,19 @@ export class SettingsTab extends PluginSettingTab {
       .addToggle(toggle =>
         toggle.setValue(settings.openInNewPane).onChange(async v => {
           settings.openInNewPane = v
+          await saveSettings(this.plugin)
+        })
+      )
+
+    // Set Vim like navigation keys
+    new Setting(containerEl)
+      .setName('Set Vim like navigation keys')
+      .setDesc(
+        'Navigate down the results with Ctrl/⌘ + J/N + or Navigate up with Ctrl/⌘ + K/P'
+      )
+      .addToggle(toggle =>
+        toggle.setValue(settings.vimLikeNavigationShortcut).onChange(async v => {
+          settings.vimLikeNavigationShortcut = v
           await saveSettings(this.plugin)
         })
       )


### PR DESCRIPTION
close #198

ref: #266

A separate commit because I'm bad at git 🤣 