### PR TITLE
Optimize splitCamelCase function performance

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -342,14 +342,15 @@ export function chunkArray<T>(arr: T[], len: number): T[][] {
  * @param text
  */
 export function splitCamelCase(text: string): string[] {
-  const split = text
+  // if no camel case found, do nothing
+  if (!/[a-z][A-Z]/.test(text)) {
+    return [];
+  }
+  const splittedText = text
     .replace(/([a-z](?=[A-Z]))/g, '$1 ')
     .split(' ')
-    .filter(t => t)
-  if (split.length > 1) {
-    return split
-  }
-  return []
+    .filter(t => t);
+  return splittedText;
 }
 
 /**


### PR DESCRIPTION
Test if contain first then split

Improvement when running on small set of text for 1000 times
<img width="327" alt="image" src="https://github.com/scambier/obsidian-omnisearch/assets/29861494/a31c3ff6-78ff-4b14-80ed-1d19a9221d20">
