### PR TITLE
Include extracted PDF content in the parent note when embedded

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -43,11 +43,9 @@ async function getAndMapIndexedDocument(
   // Just read the file content
   if (isFilePlaintext(path)) {
     content = await app.vault.cachedRead(file)
-    logDebug('Content:', content)
     // Embedded PDFs
     metadata = app.metadataCache.getFileCache(file)
     if (metadata?.embeds) {
-      logDebug('Found embeds')
       const embedFiles = metadata.embeds.map(embed => app.metadataCache.getFirstLinkpathDest(getLinkpath(embed.link), path))
       for (const file of embedFiles) {
         if (file &&
@@ -60,7 +58,6 @@ async function getAndMapIndexedDocument(
         }
       }
     }
-    else logDebug('Found NO embeds')
   }
 
   // ** Canvas **

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -1,4 +1,4 @@
-import { Notice, getLinkpath, type CachedMetadata } from 'obsidian'
+import { Notice, getLinkpath } from 'obsidian'
 import {
   type DocumentRef,
   getTextExtractor,
@@ -35,8 +35,7 @@ async function getAndMapIndexedDocument(
   const file = app.vault.getFiles().find(f => f.path === path)
   if (!file) throw new Error(`Invalid file path: "${path}"`)
   let content: string | null = null
-  let metadata: CachedMetadata | null = null
-
+  const metadata = app.metadataCache.getFileCache(file)
   const extractor = getTextExtractor()
 
   // ** Plain text **
@@ -44,7 +43,6 @@ async function getAndMapIndexedDocument(
   if (isFilePlaintext(path)) {
     content = await app.vault.cachedRead(file)
     // Embedded PDFs
-    metadata = app.metadataCache.getFileCache(file)
     if (metadata?.embeds) {
       const embedFiles = metadata.embeds.map(embed => app.metadataCache.getFirstLinkpathDest(getLinkpath(embed.link), path))
       for (const file of embedFiles) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,9 +99,9 @@ export default class OmnisearchPlugin extends Plugin {
         })
       )
       this.registerEvent(
-        this.app.vault.on('modify', async file => {
+        this.app.metadataCache.on('changed', async file => {
           if (isFileIndexable(file.path)) {
-            logDebug('Updating file', file.path)
+            logDebug('Updating metadata', file.path)
             await cacheManager.addToLiveCache(file.path)
             NotesIndex.markNoteForReindex(file)
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,7 @@ export default class OmnisearchPlugin extends Plugin {
       this.registerEvent(
         this.app.metadataCache.on('changed', async file => {
           if (isFileIndexable(file.path)) {
-            logDebug('Updating metadata', file.path)
+            logDebug('Updating file/metadata', file.path)
             await cacheManager.addToLiveCache(file.path)
             NotesIndex.markNoteForReindex(file)
           }


### PR DESCRIPTION
Note about the event listeners:
I could not find a case where the vault **modify** event triggered without also triggering the metadataCache **changed** event. So rather than having them be redundant and update the index twice, I replaced the first one with the second one.

Also! This is the first time I've ever done a pull request. Git/Github, VSCode, JavaScript/TypeScript are all new to me, so if there's anything missing that you'd normally expect, just let me know.