### PR TITLE
Add highlighting in the note path

### DIFF
--- a/src/components/ResultItemVault.svelte
+++ b/src/components/ResultItemVault.svelte
@@ -39,6 +39,7 @@
   }
   $: reg = stringsToRegex(note.foundWords)
   $: matchesTitle = getMatches(title, reg)
+  $: matchesNotePath = getMatches(notePath, reg)
   $: matchesExcerpt = cloneDeep(note.matches).map(m => {
     m.offset = m.offset - cleanedContent.offset
     return m
@@ -94,7 +95,7 @@
     {#if notePath}
       <div class="omnisearch-result__folder-path">
         <span bind:this="{elFolderPathIcon}"></span>
-        <span>{notePath}</span>
+        <span>{@html highlightText(notePath, matchesNotePath)}</span>
       </div>
     {/if}
 


### PR DESCRIPTION
Make the note path be highlighted too when there are matches:

![image](https://github.com/scambier/obsidian-omnisearch/assets/894561/24d3eb29-bc7d-4d4a-a578-4757f423d56a)

Fixes #318