### PR TITLE
Index office documents

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -13,6 +13,7 @@ import {
   isFileFromDataloomPlugin,
   isFileImage,
   isFilePDF,
+  isFileOffice,
   isFilePlaintext,
   isFilenameIndexable,
   logDebug,
@@ -101,6 +102,15 @@ async function getAndMapIndexedDocument(
   else if (
     isFilePDF(path) &&
     settings.PDFIndexing &&
+    extractor?.canFileBeExtracted(path)
+  ) {
+    content = await extractor.extractText(file)
+  }
+
+  // ** Office document **
+  else if (
+    isFileOffice(path) &&
+    settings.officeIndexing &&
     extractor?.canFileBeExtracted(path)
   ) {
     content = await extractor.extractText(file)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,6 +37,8 @@ export interface OmnisearchSettings extends WeightingSettings {
   PDFIndexing: boolean
   /** Enable Images indexing */
   imagesIndexing: boolean
+  /** Enable Office documents indexing */
+  officeIndexing: boolean
   /** Enable Excalidraw indexing */
   excalidrawIndexing: boolean
   /** Enable indexing of unknown files */
@@ -160,11 +162,30 @@ export class SettingsTab extends PluginSettingTab {
       )
       .setDisabled(!getTextExtractor())
 
+    // Office Documents Indexing
+    const indexOfficesDesc = new DocumentFragment()
+    indexOfficesDesc.createSpan({}, span => {
+      span.innerHTML = `Omnisearch will use Text Extractor to index the content of your office documents (currently <pre style="display:inline">.docx</pre> and <pre style="display:inline">.xlsx</pre>)`
+    })
+    new Setting(containerEl)
+      .setName(
+        `Documents content indexing ${getTextExtractor() ? '' : '⚠️ Disabled'}`
+      )
+      .setDesc(indexOfficesDesc)
+      .addToggle(toggle =>
+        toggle.setValue(settings.officeIndexing).onChange(async v => {
+          await database.clearCache()
+          settings.officeIndexing = v
+          await saveSettings(this.plugin)
+        })
+      )
+      .setDisabled(!getTextExtractor())
+
     // Index filenames of unsupported files
     const indexUnsupportedDesc = new DocumentFragment()
     indexUnsupportedDesc.createSpan({}, span => {
       span.innerHTML = `
-      Omnisearch can index file<strong>names</strong> of "unsupported" files, such as e.g. <pre style="display:inline">.mp4</pre>, <pre style="display:inline">.xlsx</pre>, 
+      Omnisearch can index file<strong>names</strong> of "unsupported" files, such as e.g. <pre style="display:inline">.mp4</pre>
       or non-extracted PDFs & images.<br/>
       "Obsidian setting" will respect the value of "Files & Links > Detect all file extensions"`
     })
@@ -177,7 +198,7 @@ export class SettingsTab extends PluginSettingTab {
           .setValue(settings.unsupportedFilesIndexing)
           .onChange(async v => {
             await database.clearCache()
-            ;(settings.unsupportedFilesIndexing as any) = v
+              ; (settings.unsupportedFilesIndexing as any) = v
             await saveSettings(this.plugin)
           })
       })
@@ -187,7 +208,7 @@ export class SettingsTab extends PluginSettingTab {
     indexedFileTypesDesc.createSpan({}, span => {
       span.innerHTML = `In addition to standard <code>md</code> files, Omnisearch can also index other <strong style="color: var(--text-accent)">PLAINTEXT</strong> files.<br/>
       Add extensions separated by a space, without the dot. Example: "<code>txt org csv</code>".<br />
-      ⚠️ <span style="color: var(--text-accent)">Using extensions of non-plaintext files (like .docx or .pptx) WILL cause crashes,
+      ⚠️ <span style="color: var(--text-accent)">Using extensions of non-plaintext files (like .pptx) WILL cause crashes,
       because Omnisearch will try to index their content.</span>`
     })
     new Setting(containerEl)
@@ -604,6 +625,7 @@ export const DEFAULT_SETTINGS: OmnisearchSettings = {
   ignoreDiacritics: true,
   indexedFileTypes: [] as string[],
   PDFIndexing: false,
+  officeIndexing: false,
   imagesIndexing: false,
   excalidrawIndexing: true,
   unsupportedFilesIndexing: 'no',

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -174,6 +174,11 @@ export function isFilePDF(path: string): boolean {
   return getExtension(path) === 'pdf'
 }
 
+export function isFileOffice(path: string): boolean {
+  const ext = getExtension(path)
+  return ext === 'docx' || ext === 'xlsx'
+}
+
 export function isFilePlaintext(path: string): boolean {
   return [...settings.indexedFileTypes, 'md'].some(t => path.endsWith(`.${t}`))
 }


### PR DESCRIPTION
Since the text-extractor now supports Office documents (scambier/obsidian-text-extractor#52), this PR adds the option to index them.