### PR TITLE
Add sandboxing to the sponsor button iframe

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,7 +102,7 @@ export class SettingsTab extends PluginSettingTab {
     // Sponsor link - Thank you!
     const divSponsor = containerEl.createDiv()
     divSponsor.innerHTML = `
-        <iframe src="https://github.com/sponsors/scambier/button" title="Sponsor scambier" height="35" width="116" style="border: 0;"></iframe>
+        <iframe sandbox="allow-top-navigation-by-user-activation" src="https://github.com/sponsors/scambier/button" title="Sponsor scambier" height="35" width="116" style="border: 0;"></iframe>
         <a href='https://ko-fi.com/B0B6LQ2C' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://cdn.ko-fi.com/cdn/kofi2.png?v=3' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a> 
     `
 


### PR DESCRIPTION
Adding the sandbox attribute to the sponsor button iframe protects the local Obsidian instance against potentially malicious code from the iframe source. Not that we don't trust you! :D 

This is unlikely to be a huge exploit since someone would have to compromise github's sponsor button, but it does stop code scanners from noticing this line, which is nice (and removes an annoyance for my personal use case!)

I've tested with the "allow-top-navigation-by-user-activation" value and it still pops up a browser window with the support page.