### PR TITLE
Add ability to downrank some folders in the results

### DIFF
--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -373,7 +373,7 @@
     <span>to insert a link</span>
   </div>
   <div class="prompt-instruction">
-    <span class="prompt-instruction-command">ctrl g</span>
+    <span class="prompt-instruction-command">ctrl h</span>
     <span>to toggle excerpts</span>
   </div>
   <div class="prompt-instruction">

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -373,7 +373,7 @@
     <span>to insert a link</span>
   </div>
   <div class="prompt-instruction">
-    <span class="prompt-instruction-command">ctrl h</span>
+    <span class="prompt-instruction-command">ctrl g</span>
     <span>to toggle excerpts</span>
   </div>
   <div class="prompt-instruction">

--- a/src/components/modals.ts
+++ b/src/components/modals.ts
@@ -136,7 +136,7 @@ abstract class OmnisearchModal extends Modal {
     })
 
     // Context
-    this.scope.register(['Ctrl'], 'H', _e => {
+    this.scope.register(['Ctrl'], 'G', _e => {
       eventBus.emit(EventNames.ToggleExcerpts)
     })
   }

--- a/src/search/omnisearch.ts
+++ b/src/search/omnisearch.ts
@@ -252,32 +252,35 @@ export class Omnisearch {
       })
     }
 
-    logDebug('searching with downranked folders', settings.downrankedFoldersFilters);
+    logDebug(
+      'searching with downranked folders',
+      settings.downrankedFoldersFilters
+    )
     // downrank files that are in folders listed in the downrankedFoldersFilters
     if (settings.downrankedFoldersFilters.length > 0) {
       results.forEach(result => {
-        const path = result.id;
-        let downrankingFolder = false;
+        const path = result.id
+        let downrankingFolder = false
         settings.downrankedFoldersFilters.forEach(filter => {
           if (path.startsWith(filter)) {
             // we don't want the filter to match the folder sources, e.g.
             // it needs to match a whole folder name
             if (path === filter || path.startsWith(filter + '/')) {
-              logDebug('searching with downranked folders in path: ', path);
-              downrankingFolder = true;
+              logDebug('searching with downranked folders in path: ', path)
+              downrankingFolder = true
             }
           }
         })
         if (downrankingFolder) {
           result.score /= 10
         }
-        const pathParts = path.split('/');
-        const pathPartsLength = pathParts.length;
+        const pathParts = path.split('/')
+        const pathPartsLength = pathParts.length
         for (let i = 0; i < pathPartsLength; i++) {
-          const pathPart = pathParts[i];
+          const pathPart = pathParts[i]
           if (settings.downrankedFoldersFilters.includes(pathPart)) {
             result.score /= 10
-            break;
+            break
           }
         }
       })

--- a/src/search/omnisearch.ts
+++ b/src/search/omnisearch.ts
@@ -252,6 +252,37 @@ export class Omnisearch {
       })
     }
 
+    logDebug('searching with downranked folders', settings.downrankedFoldersFilters);
+    // downrank files that are in folders listed in the downrankedFoldersFilters
+    if (settings.downrankedFoldersFilters.length > 0) {
+      results.forEach(result => {
+        const path = result.id;
+        var downrankingFolder = false;
+        logDebug('searching with downranked folders, got path: ', path);
+        settings.downrankedFoldersFilters.forEach(filter => {
+          if (path.startsWith(filter)) {
+            // we don't want the filter sou to match the folder sources, e.g.
+            // it needs to match a whole folder name
+            if (path === filter || path.startsWith(filter + '/')) {
+              downrankingFolder = true;
+            }
+          }
+        })
+        if (downrankingFolder) {
+          result.score /= 10
+        }
+        const pathParts = path.split('/');
+        const pathPartsLength = pathParts.length;
+        for (let i = 0; i < pathPartsLength; i++) {
+          const pathPart = pathParts[i];
+          if (settings.downrankedFoldersFilters.includes(pathPart)) {
+            result.score /= 10
+            break;
+          }
+        }
+      })
+    }
+
     // Extract tags from the query
     const tags = query.getTags()
 

--- a/src/search/omnisearch.ts
+++ b/src/search/omnisearch.ts
@@ -258,12 +258,12 @@ export class Omnisearch {
       results.forEach(result => {
         const path = result.id;
         let downrankingFolder = false;
-        logDebug('searching with downranked folders, got path: ', path);
         settings.downrankedFoldersFilters.forEach(filter => {
           if (path.startsWith(filter)) {
-            // we don't want the filter sou to match the folder sources, e.g.
+            // we don't want the filter to match the folder sources, e.g.
             // it needs to match a whole folder name
             if (path === filter || path.startsWith(filter + '/')) {
+              logDebug('searching with downranked folders in path: ', path);
               downrankingFolder = true;
             }
           }

--- a/src/search/omnisearch.ts
+++ b/src/search/omnisearch.ts
@@ -257,7 +257,7 @@ export class Omnisearch {
     if (settings.downrankedFoldersFilters.length > 0) {
       results.forEach(result => {
         const path = result.id;
-        var downrankingFolder = false;
+        let downrankingFolder = false;
         logDebug('searching with downranked folders, got path: ', path);
         settings.downrankedFoldersFilters.forEach(filter => {
           if (path.startsWith(filter)) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -283,7 +283,7 @@ export class SettingsTab extends PluginSettingTab {
           .onChange(async v => {
             let folders = v.split(',')
             folders = folders.map(f => f.trim())
-            settings.downrankedFoldersFilters = folders;
+            settings.downrankedFoldersFilters = folders
             await saveSettings(this.plugin)
           })
       })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -29,6 +29,8 @@ export interface OmnisearchSettings extends WeightingSettings {
   useCache: boolean
   /** Respect the "excluded files" Obsidian setting by downranking results ignored files */
   hideExcluded: boolean
+  /** downrank files in the given folders */
+  downrankedFoldersFilters: string[]
   /** Ignore diacritics when indexing files */
   ignoreDiacritics: boolean
   /** Extensions of plain text files to index, in addition to .md */
@@ -267,6 +269,22 @@ export class SettingsTab extends PluginSettingTab {
           await saveSettings(this.plugin)
         })
       )
+
+    // Downranked files
+    new Setting(containerEl)
+      .setName('Folders to downrank in search results')
+      .setDesc(
+        `Folders to downrank in search results. Files in these folders will be downranked in results.  They will still be indexed for tags, unlike excluded files.  Folders should be comma delimited.`
+      )
+      .addText(component => {
+        component
+          .setValue(settings.downrankedFoldersFilters.join(','))
+          .setPlaceholder('Example: src,p2/dir')
+          .onChange(async v => {
+            settings.downrankedFoldersFilters = v.split(',')
+            await saveSettings(this.plugin)
+          })
+      })
 
     // Split CamelCaseWords
     const camelCaseDesc = new DocumentFragment()
@@ -621,6 +639,7 @@ export class SettingsTab extends PluginSettingTab {
 export const DEFAULT_SETTINGS: OmnisearchSettings = {
   useCache: true,
   hideExcluded: false,
+  downrankedFoldersFilters: [] as string[],
   ignoreDiacritics: true,
   indexedFileTypes: [] as string[],
   PDFIndexing: false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -281,7 +281,9 @@ export class SettingsTab extends PluginSettingTab {
           .setValue(settings.downrankedFoldersFilters.join(','))
           .setPlaceholder('Example: src,p2/dir')
           .onChange(async v => {
-            settings.downrankedFoldersFilters = v.split(',')
+            let folders = v.split(',')
+            folders = folders.map(f => f.trim())
+            settings.downrankedFoldersFilters = folders;
             await saveSettings(this.plugin)
           })
       })


### PR DESCRIPTION
Add ability to have some downranked folders that are separate from the obsidian exclude folders.  I added this because the obsidian exclude folders are excluded from tags as well, and so I don't want to use the obsidian exclude folders.