### PR TITLE
Add shortcut to open note in a new split pane (Issue #202)

### DIFF
--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -47,6 +47,7 @@
   let openInCurrentPaneKey: string
   let createInNewPaneKey: string
   let createInCurrentPaneKey: string
+  let openInNewLeafKey: string = getCtrlKeyLabel() + ' alt ↵'
 
   $: selectedNote = resultNotes[selectedIndex]
   $: searchQuery = searchQuery ?? previousQuery
@@ -101,6 +102,7 @@
     eventBus.on('vault', Action.ArrowDown, () => moveIndex(1))
     eventBus.on('vault', Action.PrevSearchHistory, prevSearchHistory)
     eventBus.on('vault', Action.NextSearchHistory, nextSearchHistory)
+    eventBus.on('vault', Action.OpenInNewLeaf, openNoteInNewLeaf)
     await NotesIndex.refreshIndex()
     await updateResultsDebounced()
   })
@@ -178,16 +180,26 @@
     modal.close()
   }
 
+  function openNoteInNewLeaf(): void {
+    if (!selectedNote) return
+    openSearchResult(selectedNote, true, true)
+    modal.close()
+  }
+
   function saveCurrentQuery() {
     if (searchQuery) {
       cacheManager.addToSearchHistory(searchQuery)
     }
   }
 
-  function openSearchResult(note: ResultNote, newPane = false) {
+  function openSearchResult(
+    note: ResultNote,
+    newPane = false,
+    newLeaf = false
+  ) {
     saveCurrentQuery()
     const offset = note.matches?.[0]?.offset ?? 0
-    openNote(note, offset, newPane)
+    openNote(note, offset, newPane, newLeaf)
   }
 
   async function onClickCreateNote(_e: MouseEvent) {
@@ -352,6 +364,11 @@
   <div class="prompt-instruction">
     <span class="prompt-instruction-command">{openInNewPaneKey}</span>
     <span>to open in a new pane</span>
+  </div>
+
+  <div class="prompt-instruction">
+    <span class="prompt-instruction-command">{openInNewLeafKey}</span>
+    <span>to open in a new split</span>
   </div>
 
   <div class="prompt-instruction">

--- a/src/components/modals.ts
+++ b/src/components/modals.ts
@@ -68,6 +68,7 @@ abstract class OmnisearchModal extends Modal {
     let openInNewPaneKey: Modifier[]
     let createInCurrentPaneKey: Modifier[]
     let createInNewPaneKey: Modifier[]
+    let openInNewLeafKey: Modifier[] = ['Mod', 'Alt']
     if (settings.openInNewPane) {
       openInCurrentPaneKey = ['Mod']
       openInNewPaneKey = []
@@ -84,6 +85,12 @@ abstract class OmnisearchModal extends Modal {
     this.scope.register(openInNewPaneKey, 'Enter', e => {
       e.preventDefault()
       eventBus.emit(Action.OpenInNewPane)
+    })
+
+    // Open in a new leaf
+    this.scope.register(openInNewLeafKey, 'Enter', e => {
+      e.preventDefault()
+      eventBus.emit(Action.OpenInNewLeaf)
     })
 
     // Insert link

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -43,6 +43,7 @@ export const enum Action {
   ArrowDown = 'arrow-down',
   PrevSearchHistory = 'prev-search-history',
   NextSearchHistory = 'next-search-history',
+  OpenInNewLeaf = 'open-in-new-leaf',
 }
 
 export type DocumentRef = { path: string; mtime: number }

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -5,7 +5,8 @@ import { stringsToRegex } from './text-processing'
 export async function openNote(
   item: ResultNote,
   offset = 0,
-  newPane = false
+  newPane = false,
+  newLeaf = false
 ): Promise<void> {
   // Check if the note is already open,
   // to avoid opening it twice if the first one is pinned
@@ -25,7 +26,7 @@ export async function openNote(
 
   if (!alreadyOpenAndPinned) {
     // Open the note normally
-    await app.workspace.openLinkText(item.path, '', newPane)
+    await app.workspace.openLinkText(item.path, '', newLeaf ? 'split' : newPane)
   }
 
   const view = app.workspace.getActiveViewOfType(MarkdownView)


### PR DESCRIPTION
This adds the shortcut `cmd/ctrl + alt + enter` to the search modal to open a found file in a new leaf. I used the term "split" in user-facing text, because I think that's the more common nomenclature.

Some things to note:
- This function ignores the existing "open in new pane by default" setting. I didn't seem relevant with this action.
- It also does not check to see if the file is already open. It will continue opening the value in a new split as often as the user wants.
- As-is it will always split to the immediate right.
