### PR TITLE
Update README.md for using Chinese split plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can check the [CHANGELOG](./CHANGELOG.md) for more information on the differ
 - Supports Vim navigation keys
 
 **Note:** support of Chinese depends
-on [this additional plugin](https://github.com/aidenlx/cm-chs-patch). Please read its documentation for more
+on [this additional plugin](https://github.com/aidenlx/cm-chs-patch) (also you may need to clear search cache data to apply new Chinese index). Please read its documentation for more
 information.
 
 ## Projects that use Omnisearch


### PR DESCRIPTION
After using Omnisearch for some time, I noticed that the Chinese search results were not accurate today. I followed the instructions in the README and installed the [Chinese patch plugin](https://github.com/aidenlx/cm-chs-patch). However, the plugin did not work immediately.

I suspect the issue is due to outdated cache data following the installation of the new [plugin](https://github.com/aidenlx/cm-chs-patch).

This pull request provides a usage tip for the [Chinese patch plugin](https://github.com/aidenlx/cm-chs-patch).