### PR TITLE
perf: combine token split into 1 pass

### DIFF
--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -27,15 +27,11 @@ export class Tokenizer {
       }
 
       let tokens = this.tokenizeTokens(text, { skipChs: true })
-
-      // Split hyphenated tokens
-      tokens = [...tokens, ...tokens.flatMap(splitHyphens)]
-
-      // Split camelCase tokens into "camel" and "case
-      tokens = [...tokens, ...tokens.flatMap(splitCamelCase)]
-
-      // Add whole words (aka "not tokens")
-      tokens = [...tokens, ...words]
+      tokens = [...tokens.flatMap(token => [
+        token,
+        ...splitHyphens(token),
+        ...splitCamelCase(token),
+      ]), ...words]
 
       // Add urls
       if (urls.length) {


### PR DESCRIPTION
Comparison:
After: 2149.198974609375 ms
Before: 2500.649169921875 ms

One downside of this is that it wont handle word with mixed camel and hypen. But thats really rare so I think this trade off is acceptable
