### PR TITLE
perf: batch cache processing

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -38,8 +38,8 @@ export class Database extends Dexie {
     data: AsPlainObject
   } | null> {
     try {
-      const cachedIndex = (await this.plugin.database.minisearch.toArray())[0]
-      return cachedIndex
+      const cachedIndex = await this.plugin.database.minisearch.limit(1).first()
+      return cachedIndex ? { paths: cachedIndex.paths, data: cachedIndex.data } : null
     } catch (e) {
       new Notice(
         'Omnisearch - Cache missing or invalid. Some freezes may occur while Omnisearch indexes your vault.'

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -189,6 +189,19 @@ export function makeMD5(data: BinaryLike): string {
   return createHash('md5').update(data).digest('hex')
 }
 
+/**
+ * Splits an array into chunks of a specified length.
+ * 
+ * @param arr - The input array to be chunked
+ * @param len - The length of each chunk
+ * @returns An array of arrays, where each inner array has at most `len` elements
+ * 
+ * @example
+ * ```typescript
+ * chunkArray([1, 2, 3, 4, 5], 2)
+ * // returns [[1, 2], [3, 4], [5]]
+ * ```
+ */
 export function chunkArray<T>(arr: T[], len: number): T[][] {
   const chunks = []
   let i = 0


### PR DESCRIPTION
This patch is recommended by AI, and it reduces the time from

Loading index from cache: 1383.408935546875 ms
plugin:omnisearch:104 Indexing total time: 1385.22607421875 ms

to

Loading index from cache: 1216.864013671875 ms
plugin:omnisearch:106 Indexing total time: 1218.73291015625 ms

May need more testing though