### PR TITLE
feat: Allow #heading as display title setting

### DIFF
--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -240,9 +240,10 @@
     // Generate link
     let link: string
     if (file && active) {
-      link = plugin.app.fileManager.generateMarkdownLink(file, active.path)
+      link = plugin.app.fileManager.generateMarkdownLink(file, active.path, "", selectedNote.displayTitle)
     } else {
-      link = `[[${selectedNote.basename}.${getExtension(selectedNote.path)}]]`
+      let maybeDisplayTitle = selectedNote.displayTitle === "" ? "" : `|${selectedNote.displayTitle}`
+      link = `[[${selectedNote.basename}.${getExtension(selectedNote.path)}${maybeDisplayTitle}]]`
     }
 
     // Inject link

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -242,7 +242,7 @@
     if (file && active) {
       link = plugin.app.fileManager.generateMarkdownLink(file, active.path, "", selectedNote.displayTitle)
     } else {
-      let maybeDisplayTitle = selectedNote.displayTitle === "" ? "" : `|${selectedNote.displayTitle}`
+      const maybeDisplayTitle = selectedNote.displayTitle === "" ? "" : `|${selectedNote.displayTitle}`
       link = `[[${selectedNote.basename}.${getExtension(selectedNote.path)}${maybeDisplayTitle}]]`
     }
 

--- a/src/components/ResultItemVault.svelte
+++ b/src/components/ResultItemVault.svelte
@@ -169,13 +169,13 @@
             ></span>
           {/if}
         {/if}
-        {#if note.displayTitle}
-        <span>{@html plugin.textProcessor.highlightText(title, matchesTitle)}</span>
-        {:else}
-        <span>{@html plugin.textProcessor.highlightText(title, matchesTitle)}</span>
-        <span class="omnisearch-result__extension">
-          .{getExtension(note.path)}
+        <span>
+          {@html plugin.textProcessor.highlightText(title, matchesTitle)}
         </span>
+        {#if !note.displayTitle}
+          <span class="omnisearch-result__extension">
+            .{getExtension(note.path)}
+          </span>
         {/if}
 
         <!-- Counter -->

--- a/src/components/ResultItemVault.svelte
+++ b/src/components/ResultItemVault.svelte
@@ -169,12 +169,14 @@
             ></span>
           {/if}
         {/if}
-        <span>
-          {@html plugin.textProcessor.highlightText(title, matchesTitle)}
-        </span>
+        {#if note.displayTitle}
+        <span>{@html plugin.textProcessor.highlightText(title, matchesTitle)}</span>
+        {:else}
+        <span>{@html plugin.textProcessor.highlightText(title, matchesTitle)}</span>
         <span class="omnisearch-result__extension">
           .{getExtension(note.path)}
         </span>
+        {/if}
 
         <!-- Counter -->
         {#if note.matches.length > 0}

--- a/src/repositories/documents-repository.ts
+++ b/src/repositories/documents-repository.ts
@@ -216,8 +216,8 @@ export class DocumentsRepository {
       }
     }
     let displayTitle: string
-    if (this.plugin.settings.displayTitle == '#heading') {
-      displayTitle = metadata?.headings?.find(h => h.level == 1)?.heading ?? ''
+    if (this.plugin.settings.displayTitle === '#heading') {
+      displayTitle = metadata?.headings?.find(h => h.level === 1)?.heading ?? ''
     } else {
       displayTitle = metadata?.frontmatter?.[this.plugin.settings.displayTitle] ?? ''
     }

--- a/src/repositories/documents-repository.ts
+++ b/src/repositories/documents-repository.ts
@@ -215,8 +215,12 @@ export class DocumentsRepository {
         }
       }
     }
-    const displayTitle =
-      metadata?.frontmatter?.[this.plugin.settings.displayTitle] ?? ''
+    let displayTitle: string
+    if (this.plugin.settings.displayTitle == '#heading') {
+      displayTitle = metadata?.headings?.find(h => h.level == 1)?.heading ?? ''
+    } else {
+      displayTitle = metadata?.frontmatter?.[this.plugin.settings.displayTitle] ?? ''
+    }
     const tags = getTagsFromMetadata(metadata)
     return {
       basename: file.basename,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -242,7 +242,7 @@ export class SettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Set frontmatter property key as title')
       .setDesc(
-        htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results. Also you can use #heading to use the first Heading from a file.<br>
+        htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results. If you set this to #heading, then use the first heading from a file as the title.<br>
           Leave empty to disable.`)
       )
       .addText(component => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -242,7 +242,7 @@ export class SettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Set frontmatter property key as title')
       .setDesc(
-        htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results.<br>
+        htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results. Also you can use #heading to use the first Heading from a file.<br>
           Leave empty to disable.`)
       )
       .addText(component => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -242,7 +242,7 @@ export class SettingsTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName('Set frontmatter property key as title')
       .setDesc(
-        htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results. If you set this to #heading, then use the first heading from a file as the title.<br>
+        htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results. If you set this to '#heading', then use the first heading from a file as the title.<br>
           Leave empty to disable.`)
       )
       .addText(component => {


### PR DESCRIPTION
## Feature

This PR allows `#heading` to be a valid setting for the "Set frontmatter key as title" setting (i.e. display title). When this setting is set to `#heading`, then the first level-1 heading in the file is selected as the tile, otherwise empty.

## Use case

I use a zettelkasten with filenames that are arbitrary IDs and files where the title is the first heading and there is no front-matter. So my directory looks like this
```
zk/
├── 0244.md
├── 7w9u.md
├── iln7.md
├── u42m.md
└── zhet.md
```

And an example file looks like this
```md
# rustconf 2024: rust for linux

goal of rust for linux:
> To make it so that anything in the Kernel you can do with C, you could also do with Rust.

why? to make kernel development more accessible to get more developers and to reduce the chance of bugs in the kernel. also in the process of working on this, to improve documentation and other aspects of the kernel.
...
```

In order to have search results that show a meaningful title, I set the display title setting to `#heading`. 

### Before
<img width="738" alt="Image of search results without #heading" src="https://github.com/user-attachments/assets/007b2a9e-a7a2-435e-871b-1486e639811a" />

### After
<img width="750" alt="Image of search results with #heading" src="https://github.com/user-attachments/assets/d8d59d13-a9c6-46fe-b552-38956bd5ab39" />

## Background

I've maintained this small diff locally for awhile (~6 months). I decided it might be useful to some other people, so I'm trying to upstream it.

The usage of `#heading` as the setting was inspired by the plugin [Front Matter Title](https://github.com/snezhig/obsidian-front-matter-title).