### PR TITLE
feat: Support multiple displayTitle sources with fallback

### DIFF
--- a/src/repositories/documents-repository.ts
+++ b/src/repositories/documents-repository.ts
@@ -221,12 +221,26 @@ export class DocumentsRepository {
         }
       }
     }
-    let displayTitle: string
-    if (this.plugin.settings.displayTitle === '#heading') {
-      displayTitle = metadata?.headings?.find(h => h.level === 1)?.heading ?? ''
-    } else {
-      displayTitle =
-        metadata?.frontmatter?.[this.plugin.settings.displayTitle] ?? ''
+    let displayTitle = ''
+    const displayTitleSetting = this.plugin.settings.displayTitle
+
+    if (displayTitleSetting) {
+      const sources = displayTitleSetting.split(',').map(s => s.trim()).filter(s => s)
+
+      for (const source of sources) {
+        let value = ''
+
+        if (source === '#heading') {
+          value = metadata?.headings?.find(h => h.level === 1)?.heading ?? ''
+        } else {
+          value = metadata?.frontmatter?.[source] ?? ''
+        }
+
+        if (value) {
+          displayTitle = value
+          break
+        }
+      }
     }
     const tags = getTagsFromMetadata(metadata)
     return {

--- a/src/settings/settings-indexing.ts
+++ b/src/settings/settings-indexing.ts
@@ -129,15 +129,21 @@ export function injectSettingsIndexing(
   new Setting(containerEl)
     .setName('Set frontmatter property key as title')
     .setDesc(
-      htmlDescription(`If you have a custom property in your notes that you want to use as the title in search results. If you set this to '#heading', then use the first heading from a file as the title.<br>
+      htmlDescription(`Custom property in your notes to use as the title in search results.<br>
+          Use <code>#heading</code> to use the first H1 heading.<br>
+          <strong>Fallback support:</strong> Separate multiple sources with commas. The first non-empty value will be used.<br>
+          Example: <code>#heading,title,name</code> tries H1 first, then frontmatter "title", then "name".<br>
           Leave empty to disable.`)
     )
     .addText(component => {
-      component.setValue(settings.displayTitle).onChange(async v => {
-        await clearCacheDebounced()
-        settings.displayTitle = v
-        await saveSettings(plugin)
-      })
+      component
+        .setPlaceholder('e.g., #heading,title')
+        .setValue(settings.displayTitle)
+        .onChange(async v => {
+          await clearCacheDebounced()
+          settings.displayTitle = v
+          await saveSettings(plugin)
+        })
     })
 
   // Additional text files to index


### PR DESCRIPTION
  ## Summary
  - Allow users to specify multiple title sources separated by commas (e.g., `#heading,title,name`)
  - The first non-empty value is used, providing a fallback mechanism
  - Fully backward compatible with existing single-value settings

  ## Related Issue
  Closes #468

  ## Changes
  - **`src/repositories/documents-repository.ts`**: Implement comma-separated source parsing with fallback logic
  - **`src/settings/settings-indexing.ts`**: Update setting description to explain new syntax and add placeholder

  ## Example Usage
  | Setting | Behavior |
  |---------|----------|
  | `title` | Same as before - use frontmatter "title" |
  | `#heading` | Same as before - use first H1 heading |
  | `#heading,title` | Try H1 first, fallback to frontmatter "title" |
  | `#heading,title,name` | Try H1, then "title", then "name" |

  ## Tested
  - [x] Build passes without errors
  - [x] Single value settings work as before
  - [x] Multiple sources with fallback work correctly
  - [x] Whitespace around commas is trimmed properly
  - [x] Empty sources are filtered out
