### PR TITLE
fix: Hebrew/Arabic diacritics support + highlight corrections

### DIFF
--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -459,31 +459,27 @@ export class SearchEngine {
         } as IndexedDocument
       }
 
-      // Clean search matches that match quoted expressions,
-      // and inject those expressions instead
+      // Use the user's actual query terms for highlighting, not MiniSearch's
+      // result.terms (which can include fuzzy matches like "תקיש" for "תקון").
+      // This way we only highlight what the user searched for.
       const foundWords = [
-        // Matching terms from the result,
-        // do not necessarily match the query
-        ...result.terms,
-
-        // Quoted expressions
+        ...query.query.text,
         ...query.getExactTerms(),
-
-        // Tags, starting with #
         ...query.getTags(),
-      ]
-      logVerbose('Matching tokens:', foundWords)
+      ].filter(Boolean)
+      const uniqueFoundWords = [...new Set(foundWords)]
+      logVerbose('Matching tokens (query terms for highlight):', uniqueFoundWords)
 
       logVerbose('Getting matches locations...')
       const matches = this.plugin.textProcessor.getMatches(
         note.content,
-        foundWords,
+        uniqueFoundWords,
         query
       )
       logVerbose(`Matches for note "${note.path}"`, matches)
       const resultNote: ResultNote = {
         score: result.score,
-        foundWords,
+        foundWords: uniqueFoundWords,
         matches,
         isEmbed: result.isEmbed,
         ...note,

--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -7,10 +7,11 @@ import type OmnisearchPlugin from '../main'
 
 // When matching with "ignore diacritics", allow these between base letters so we
 // search the original text and get correct indices (normalized text has different length).
+// Exclude U+05BE (maqaf ־) — it's a hyphen, not a diacritic.
 const OPTIONAL_DIACRITICS_CLASS =
-  '[\\u0591-\\u05C7\\u0300-\\u036f]' // Hebrew nikud + Latin combining
+  '[\\u0591-\\u05BD\\u05BF-\\u05C7\\u0300-\\u036f]' // Hebrew nikud + Latin combining
 const OPTIONAL_DIACRITICS_CLASS_ARABIC =
-  '[\\u0591-\\u05C7\\u0300-\\u036f\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7\\u06E8\\u06EA-\\u06ED]'
+  '[\\u0591-\\u05BD\\u05BF-\\u05C7\\u0300-\\u036f\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7\\u06E8\\u06EA-\\u06ED]'
 
 export class TextProcessor {
   constructor(private plugin: OmnisearchPlugin) {}
@@ -105,7 +106,9 @@ export class TextProcessor {
         .map(w => this.regexForWordWithOptionalDiacritics(w, arabic))
         .filter(Boolean)
       if (!patterns.length) return []
-      const joined = `(?:${patterns.map(p => `\\b(?:${p})\\b|(?:${p})`).join('|')})`
+      // Don't use \b word boundaries — they're unreliable with Hebrew in many engines.
+      // Match the pattern (word + optional diacritics) anywhere; prefix matches still work.
+      const joined = `(?:${patterns.map(p => `(?:${p})`).join('|')})`
       reg = new RegExp(joined, 'giu')
       searchText = originalText
     } else {

--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -5,6 +5,13 @@ import { Notice } from 'obsidian'
 import { escapeRegExp } from 'lodash-es'
 import type OmnisearchPlugin from '../main'
 
+// When matching with "ignore diacritics", allow these between base letters so we
+// search the original text and get correct indices (normalized text has different length).
+const OPTIONAL_DIACRITICS_CLASS =
+  '[\\u0591-\\u05C7\\u0300-\\u036f]' // Hebrew nikud + Latin combining
+const OPTIONAL_DIACRITICS_CLASS_ARABIC =
+  '[\\u0591-\\u05C7\\u0300-\\u036f\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7\\u06E8\\u06EA-\\u06ED]'
+
 export class TextProcessor {
   constructor(private plugin: OmnisearchPlugin) {}
 
@@ -54,6 +61,24 @@ export class TextProcessor {
   }
 
   /**
+   * Builds a regex pattern that matches a word with optional diacritics between
+   * each character. Used on the *original* text so match indices are correct
+   * (normalized text has different length and would give wrong highlight spans).
+   */
+  private regexForWordWithOptionalDiacritics(
+    word: string,
+    arabic: boolean
+  ): string {
+    const diacriticsClass = arabic
+      ? OPTIONAL_DIACRITICS_CLASS_ARABIC
+      : OPTIONAL_DIACRITICS_CLASS
+    const opt = `(?:${diacriticsClass})*`
+    const chars = [...word].map(c => escapeRegExp(c))
+    if (chars.length === 0) return ''
+    return chars.join(opt) + opt
+  }
+
+  /**
    * Returns an array of matches in the text, using the provided regex
    * @param text
    * @param reg
@@ -65,27 +90,39 @@ export class TextProcessor {
     query?: Query
   ): SearchMatch[] {
     words = words.map(escapeHTML)
-    const reg = this.stringsToRegex(words)
     const originalText = text
-    // text = text.toLowerCase().replace(new RegExp(SEPARATORS, 'gu'), ' ')
-    if (this.plugin.settings.ignoreDiacritics) {
-      text = removeDiacritics(text, this.plugin.settings.ignoreArabicDiacritics)
+    const ignoreDiacritics = this.plugin.settings.ignoreDiacritics
+    const arabic = this.plugin.settings.ignoreArabicDiacritics
+
+    let reg: RegExp
+    let searchText: string
+
+    if (ignoreDiacritics) {
+      // Match on original text with optional diacritics between letters so
+      // indices and matched strings are correct (normalized text has different length).
+      const sorted = [...words].sort((a, b) => b.length - a.length)
+      const patterns = sorted
+        .map(w => this.regexForWordWithOptionalDiacritics(w, arabic))
+        .filter(Boolean)
+      if (!patterns.length) return []
+      const joined = `(?:${patterns.map(p => `\\b(?:${p})\\b|(?:${p})`).join('|')})`
+      reg = new RegExp(joined, 'giu')
+      searchText = originalText
+    } else {
+      reg = this.stringsToRegex(words)
+      searchText = originalText
     }
+
     const startTime = new Date().getTime()
     let match: RegExpExecArray | null = null
     let matches: SearchMatch[] = []
     let count = 0
-    while ((match = reg.exec(text)) !== null) {
-      // Avoid infinite loops, stop looking after 100 matches or if we're taking too much time
+    while ((match = reg.exec(searchText)) !== null) {
       if (++count >= 100 || new Date().getTime() - startTime > 50) {
         warnVerbose('Stopped getMatches at', count, 'results')
         break
       }
-      const matchStartIndex = match.index
-      const matchEndIndex = matchStartIndex + match[0].length
-      const originalMatch = originalText
-        .substring(matchStartIndex, matchEndIndex)
-        .trim()
+      const originalMatch = match[0].trim()
       if (originalMatch && match.index >= 0) {
         matches.push({ match: originalMatch, offset: match.index })
       }
@@ -96,12 +133,18 @@ export class TextProcessor {
       query &&
       (query.query.text.length > 1 || query.getExactTerms().length > 0)
     ) {
-      const best = text.indexOf(query.getBestStringForExcerpt())
-      if (best > -1 && matches.find(m => m.offset === best)) {
-        matches.unshift({
-          offset: best,
-          match: query.getBestStringForExcerpt(),
-        })
+      const bestStr = query.getBestStringForExcerpt()
+      const bestMatch = matches.find(m => {
+        const normalized = ignoreDiacritics
+          ? removeDiacritics(m.match, arabic)
+          : m.match
+        return normalized.toLowerCase() === bestStr.toLowerCase()
+      })
+      if (bestMatch) {
+        matches = [
+          bestMatch,
+          ...matches.filter(m => m !== bestMatch),
+        ]
       }
     }
     return matches

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -111,8 +111,8 @@ export function getTagsFromMetadata(metadata: CachedMetadata | null): string[] {
 const japaneseDiacritics = ['\\u30FC', '\\u309A', '\\u3099']
 const regexpExclude = japaneseDiacritics.join('|')
 const diacriticsRegex = new RegExp(`(?!${regexpExclude})\\p{Diacritic}`, 'gu')
-// Hebrew nikud (vowels, dagesh, cantillation): U+0591–U+05C7
-const hebrewNikudRegex = /[\u0591-\u05C7]/g
+// Hebrew nikud (vowels, dagesh, cantillation): U+0591–U+05C7, excluding U+05BE (maqaf ־ hyphen)
+const hebrewNikudRegex = /[\u0591-\u05BD\u05BF-\u05C7]/g
 // Arabic harakat and small marks (only used when ignoreArabicDiacritics is on)
 const arabicHarakatRegex = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED]/g
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -111,6 +111,10 @@ export function getTagsFromMetadata(metadata: CachedMetadata | null): string[] {
 const japaneseDiacritics = ['\\u30FC', '\\u309A', '\\u3099']
 const regexpExclude = japaneseDiacritics.join('|')
 const diacriticsRegex = new RegExp(`(?!${regexpExclude})\\p{Diacritic}`, 'gu')
+// Hebrew nikud (vowels, dagesh, cantillation): U+0591–U+05C7
+const hebrewNikudRegex = /[\u0591-\u05C7]/g
+// Arabic harakat and small marks (only used when ignoreArabicDiacritics is on)
+const arabicHarakatRegex = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED]/g
 
 /**
  * https://stackoverflow.com/a/37511463
@@ -140,7 +144,12 @@ export function removeDiacritics(str: string, arabic = false): string {
   // Keep caret same as above
   str = str.replaceAll('^', '[__omnisearch__caret__]')
   // To keep right form of Korean character, NFC normalization is necessary
-  str = str.normalize('NFD').replace(diacriticsRegex, '').normalize('NFC')
+  // \p{Diacritic} covers Latin combining marks; Hebrew nikud and Arabic harakat need explicit ranges
+  str = str.normalize('NFD').replace(diacriticsRegex, '').replace(hebrewNikudRegex, '')
+  if (arabic) {
+    str = str.replace(arabicHarakatRegex, '')
+  }
+  str = str.normalize('NFC')
   str = str.replaceAll('[__omnisearch__backtick__]', '`')
   str = str.replaceAll('[__omnisearch__caret__]', '^')
   return str


### PR DESCRIPTION
_Issue filed first: Closes #373_

# Problem

With "Ignore diacritics" enabled, Hebrew (and Arabic) search is broken in multiple ways:

1. **No diacritics stripping** — Searching `תקון` doesn't find `תִּקּוּן` because Hebrew nikud (and Arabic harakat) aren't removed by the current `\p{Diacritic}` approach, which only covers Latin combining marks.

2. **Wrong highlights** — Even when results are found, highlights land on the **wrong words** (e.g. unrelated word parts scattered in excerpts), because match indices from the normalized (shorter) text are applied to the original (longer) text with nikud, cutting the wrong character spans. see: 
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/8293a2c9-6d04-4bb8-b079-3b18829ea356" />


3. **Unrelated words highlighted** — `foundWords` was populated from MiniSearch's `result.terms`, which includes fuzzy expansions, so words the user never searched for get highlighted.

# Root causes and fixes

**Fix 1 — Diacritics stripping (`src/tools/utils.ts`)**

`removeDiacritics()` uses `\p{Diacritic}` after NFD normalization, which covers Latin combining marks but **not** Hebrew nikud (U+0591–U+05C7) or Arabic harakat. These characters aren't decomposed by NFD, so they survive stripping.

→ Add explicit stripping of Hebrew nikud (U+0591–U+05BD, U+05BF–U+05C7) and, when `ignoreArabicDiacritics` is on, Arabic harakat. Maqaf (U+05BE ־) is deliberately excluded — it's a hyphen, not a diacritic; stripping it would merge words like `אֶת־הָאָרֶץ` into `אתהארץ`.

**Fix 2 — Match on original text (`src/tools/text-processing.ts`)**

The highlight code ran the match regex on **normalized** (shorter) text but used the resulting indices to slice the **original** (longer) text. Indices don't line up, so the wrong span was highlighted.

→ When "Ignore diacritics" is on, build a regex that matches each query word with **optional diacritics between base letters** and run it on the **original** text. Then `match.index` and `match[0]` refer to the real positions and the actual matched string. The regex does **not** use `\b` word boundaries — they're unreliable with Hebrew in many JS engines; the pattern is matched anywhere, and prefix matches (e.g. `תק` → `תקון`) still work.

**Fix 3 — Highlight from query terms, not result.terms (`src/search/search-engine.ts`)**

`foundWords` was populated from MiniSearch's `result.terms`, which includes fuzzy expansions (e.g. `תקיש` when searching `תקון`).

→ Use `query.query.text`, `query.getExactTerms()`, and `query.getTags()` for `foundWords` instead. Only the user's actual search terms are highlighted. Deduplicated with `new Set()`.

**Fix 4 — Best match for excerpt (`src/tools/text-processing.ts`)**

The "best match" logic used `text.indexOf()` on normalized text, producing an index that didn't correspond to the original text.

→ Find the best match by comparing the normalized version of each actual match to the query, then promote that match to the front of the results array.

# Testing

- `תקון` → finds `תִּקּוּן` in pointed text ✓
- Latin diacritics (`café` → `cafe`) still work ✓
- Japanese/Korean unaffected ✓
- Maqaf preserved: `אֶת־הָאָרֶץ` doesn't merge into `אתהארץ` ✓

# Adherence to contributing guidelines

- **Issue first:** Closes #373.
- **No new dependencies.** Changes are in existing TS utilities and search logic.
- **No UI changes.** No Svelte or CSS; existing settings and defaults unchanged.
- **Comments:** Intent and Unicode ranges commented in code (what, why).
- **Philosophy:** Improves "smartness" — simple queries like `תקון` now bring relevant results and correct highlights; no extra interactions or toggles; existing 100-match / 50ms limits keep results fast.
- **Style:** Only `.ts` files modified; formatted with Prettier ESLint.
