### PR TITLE
feat: add Hebrew proximity wildcard search

### DIFF
--- a/src/__tests__/proximity-search-tests.ts
+++ b/src/__tests__/proximity-search-tests.ts
@@ -62,6 +62,41 @@ describe('Proximity search', () => {
       expect(re.test('בשלמות')).toBe(true)
       expect(re.test('שלמה')).toBe(true)
     })
+    it('middle + applies to ALL inter-letter gaps', () => {
+      const re = patternToRegex('ש+לם')
+      // + between ש and ל should also apply between ל and ם
+      expect(re.test('שלם')).toBe(true)
+      expect(re.test('שילמה')).toBe(true)
+      expect(re.test('שלמות')).toBe(true)
+    })
+    it('middle * applies to ALL inter-letter gaps', () => {
+      const re = patternToRegex('ת*קן')
+      // * between ת and ק should also apply between ק and נ
+      expect(re.test('תקן')).toBe(true)
+      expect(re.test('תיקון')).toBe(true)
+      expect(re.test('תקונ')).toBe(true)
+    })
+    it('no middle wildcard = exact letters, leading/trailing only at edges', () => {
+      const re1 = patternToRegex('תקן')
+      expect(re1.test('תקן')).toBe(true)
+      expect(re1.test('תיקון')).toBe(false)
+
+      const re2 = patternToRegex('+שלם+')
+      // +שלם+ has NO middle wildcard — only edge wildcards
+      expect(re2.test('שלם')).toBe(true)
+      expect(re2.test('השלמות')).toBe(true)
+      expect(re2.test('בשלמות')).toBe(true)
+      // No chars allowed between root letters:
+      expect(re2.test('שילום')).toBe(false)
+    })
+    it('+ש+לם+ has middle wildcard and matches more broadly', () => {
+      const re = patternToRegex('+ש+לם+')
+      expect(re.test('שלם')).toBe(true)
+      expect(re.test('השלמות')).toBe(true)
+      expect(re.test('בשלמות')).toBe(true)
+      // Middle wildcard allows plus-set chars between letters:
+      expect(re.test('שילום')).toBe(true)
+    })
     it('final-form מ/ם interchangeable', () => {
       const re = patternToRegex('מאד')
       expect(re.test('מאד')).toBe(true)

--- a/src/__tests__/proximity-search-tests.ts
+++ b/src/__tests__/proximity-search-tests.ts
@@ -1,0 +1,128 @@
+import {
+  isProximityQuery,
+  parseProximityQuery,
+  patternToRegex,
+  tokenizeHebrew,
+  proximitySearchText,
+  proximityMatchesToSearchMatches,
+  extractRootTerms,
+} from '../search/proximity-search'
+
+const TEST_TEXT =
+  'יש צורך בתיקון השלמות של העולם מאד רבות הן הדרכים אך התיקונים בשלמות מאד חשובים לנו כולנו כי תקון עולם הוא שלמה של הנשמה מאד עמוק'
+
+describe('Proximity search', () => {
+  describe('isProximityQuery', () => {
+    it('returns true for @N(...) and @(...) queries', () => {
+      expect(isProximityQuery('@10(ת*קן +ש+למ+ מאד)')).toBe(true)
+      expect(isProximityQuery('  @5(+תקן+)  ')).toBe(true)
+      expect(isProximityQuery('@10(תקון)')).toBe(true)
+      expect(isProximityQuery('@(תקון)')).toBe(true)
+    })
+    it('returns true for RTL-typed form )N(pattern@', () => {
+      expect(isProximityQuery(')10(תקון@')).toBe(true)
+    })
+    it('returns false for normal queries', () => {
+      expect(isProximityQuery('foo bar')).toBe(false)
+      expect(isProximityQuery('תקן')).toBe(false)
+      expect(isProximityQuery('@')).toBe(false)
+    })
+  })
+
+  describe('parseProximityQuery', () => {
+    it('parses distance and space-separated patterns', () => {
+      const q = parseProximityQuery('@10(ת*קן +ש+למ+ מאד)')
+      expect(q.distance).toBe(10)
+      expect(q.patterns).toEqual(['ת*קן', '+ש+למ+', 'מאד'])
+      expect(q.regexes).toHaveLength(3)
+    })
+    it('parses RTL form )N(pattern@ as @N(pattern)', () => {
+      const q = parseProximityQuery(')10(תקון@')
+      expect(q.distance).toBe(10)
+      expect(q.patterns).toEqual(['תקון'])
+      expect(q.regexes).toHaveLength(1)
+    })
+    it('parses @(pattern) with default distance 10', () => {
+      const q = parseProximityQuery('@(תקון)')
+      expect(q.distance).toBe(10)
+      expect(q.patterns).toEqual(['תקון'])
+    })
+  })
+
+  describe('patternToRegex', () => {
+    it('compiles * to any Hebrew letter', () => {
+      const re = patternToRegex('ת*קן')
+      expect(re.test('תקן')).toBe(true)
+      expect(re.test('תיקון')).toBe(true)
+      expect(re.test('תקון')).toBe(true)
+    })
+    it('compiles + to prefix/suffix set only', () => {
+      const re = patternToRegex('+שלמ+')
+      expect(re.test('השלמות')).toBe(true)
+      expect(re.test('בשלמות')).toBe(true)
+      expect(re.test('שלמה')).toBe(true)
+    })
+    it('final-form מ/ם interchangeable', () => {
+      const re = patternToRegex('מאד')
+      expect(re.test('מאד')).toBe(true)
+      expect(re.test('םאד')).toBe(true)
+    })
+    it('final-form נ/ן interchangeable', () => {
+      const re = patternToRegex('תקן')
+      expect(re.test('תקן')).toBe(true)
+      expect(re.test('תקנ')).toBe(true)
+    })
+  })
+
+  describe('tokenizeHebrew', () => {
+    it('splits on Hebrew sequences and strips nikud', () => {
+      const tokens = tokenizeHebrew(TEST_TEXT)
+      expect(tokens.length).toBeGreaterThan(20)
+      expect(tokens[0].word).toBe('יש')
+      expect(tokens[0].normalized).toBe('יש')
+      const בתיקון = tokens.find(t => t.word.includes('תיקון'))
+      expect(בתיקון).toBeDefined()
+      expect(בתיקון!.wordIndex).toBe(2)
+    })
+  })
+
+  describe('proximitySearchText', () => {
+    it('finds proximity groups for @10(+ת*ק*ן+ +ש+למ+ מאד)', () => {
+      const query = parseProximityQuery('@10(+ת*ק*ן+ +ש+למ+ מאד)')
+      const matches = proximitySearchText(TEST_TEXT, query)
+      expect(matches.length).toBeGreaterThanOrEqual(1)
+      const words = matches.flatMap(m => m.words.map(w => w.word))
+      expect(words).toContain('בתיקון')
+      expect(words).toContain('השלמות')
+      expect(words).toContain('מאד')
+    })
+    it('single pattern returns one match per matching word', () => {
+      const query = parseProximityQuery('@5(+ת*ק*ן+)')
+      const matches = proximitySearchText(TEST_TEXT, query)
+      expect(matches.length).toBeGreaterThanOrEqual(3)
+      const matchedWords = matches.map(m => m.words[0].word)
+      expect(matchedWords).toContain('בתיקון')
+      expect(matchedWords).toContain('התיקונים')
+      expect(matchedWords).toContain('תקון')
+    })
+  })
+
+  describe('proximityMatchesToSearchMatches', () => {
+    it('converts to SearchMatch with match and offset', () => {
+      const query = parseProximityQuery('@10(מאד)')
+      const matches = proximitySearchText(TEST_TEXT, query)
+      const searchMatches = proximityMatchesToSearchMatches(matches)
+      expect(searchMatches.every(m => 'match' in m && 'offset' in m)).toBe(true)
+      expect(searchMatches.some(m => m.match === 'מאד')).toBe(true)
+    })
+  })
+
+  describe('extractRootTerms', () => {
+    it('strips * and + from patterns', () => {
+      const terms = extractRootTerms(['+ת*ק*ן+', '+ש+למ+', 'מאד'])
+      expect(terms).toContain('תקן')
+      expect(terms).toContain('שלמ')
+      expect(terms).toContain('מאד')
+    })
+  })
+})

--- a/src/search/proximity-search.ts
+++ b/src/search/proximity-search.ts
@@ -109,20 +109,68 @@ function letterClass(char: string): string {
  * * = any Hebrew letter (zero or more)
  * + = zero or more from prefix/suffix set
  * Letters get final-form equivalence.
+ *
+ * Leading/trailing wildcards apply only at the edges.
+ * If ANY wildcard (* or +) appears BETWEEN the first and last Hebrew
+ * letter, the broadest type is inserted between EVERY pair of Hebrew
+ * letters (* > +). So +ש+לם+ has middle wildcards, but +שלם+ does not.
  */
 export function patternToRegex(pattern: string): RegExp {
-  let re = ''
-  for (let i = 0; i < pattern.length; i++) {
-    const c = pattern[i]
-    if (c === '*') {
-      re += `[${HEBREW_LETTERS}]*`
-    } else if (c === '+') {
-      re += `${PLUS_CLASS}*`
-    } else if (c >= '\u05D0' && c <= '\u05EA') {
-      re += letterClass(c)
+  const chars = [...pattern]
+
+  // Locate first and last Hebrew letter
+  let firstHeb = -1
+  let lastHeb = -1
+  for (let i = 0; i < chars.length; i++) {
+    if (chars[i] >= '\u05D0' && chars[i] <= '\u05EA') {
+      if (firstHeb === -1) firstHeb = i
+      lastHeb = i
     }
-    // Skip any other characters (e.g. spaces already removed)
   }
+  if (firstHeb === -1) return /(?!)/u // no Hebrew letters — never matches
+
+  // Detect broadest wildcard BETWEEN Hebrew letters only (* beats +)
+  let hasMiddleStar = false
+  let hasMiddlePlus = false
+  for (let i = firstHeb + 1; i < lastHeb; i++) {
+    if (chars[i] === '*') hasMiddleStar = true
+    else if (chars[i] === '+') hasMiddlePlus = true
+  }
+  const middleWild = hasMiddleStar
+    ? `[${HEBREW_LETTERS}]*`
+    : hasMiddlePlus
+      ? `${PLUS_CLASS}*`
+      : ''
+
+  // Leading wildcards (before first Hebrew letter)
+  let re = ''
+  for (let i = 0; i < firstHeb; i++) {
+    if (chars[i] === '*') re += `[${HEBREW_LETTERS}]*`
+    else if (chars[i] === '+') re += `${PLUS_CLASS}*`
+  }
+
+  // Collect Hebrew letters in the core of the pattern
+  const hebrewLetters: string[] = []
+  for (let i = firstHeb; i <= lastHeb; i++) {
+    if (chars[i] >= '\u05D0' && chars[i] <= '\u05EA') {
+      hebrewLetters.push(chars[i])
+    }
+  }
+
+  // Build core: each letter with optional middle wildcard between pairs
+  for (let i = 0; i < hebrewLetters.length; i++) {
+    re += letterClass(hebrewLetters[i])
+    if (i < hebrewLetters.length - 1 && middleWild) {
+      re += middleWild
+    }
+  }
+
+  // Trailing wildcards (after last Hebrew letter)
+  for (let i = lastHeb + 1; i < chars.length; i++) {
+    if (chars[i] === '*') re += `[${HEBREW_LETTERS}]*`
+    else if (chars[i] === '+') re += `${PLUS_CLASS}*`
+  }
+
   return new RegExp(`^${re}$`, 'u')
 }
 

--- a/src/search/proximity-search.ts
+++ b/src/search/proximity-search.ts
@@ -1,0 +1,328 @@
+import type { SearchMatch } from '../globals'
+
+// Hebrew letter range (א-ת)
+const HEBREW_LETTERS = '\u05D0-\u05EA'
+// Nikud and cantillation: \u0591-\u05C7, \u05F0-\u05F4
+const NIKUD_REGEX = /[\u0591-\u05C7\u05F0-\u05F4]/g
+
+// Plus wildcard: א, ב, ה, ו, י, כ, ך, ל, מ, ם, ש, ת
+const PLUS_CHARS = 'אבהויךכלםמשת'
+const PLUS_CLASS = `[${PLUS_CHARS}]`
+
+// Final-form pairs (interchangeable in matching)
+const FINAL_FORMS: Record<string, string> = {
+  מ: 'מם',
+  ם: 'מם',
+  נ: 'נן',
+  ן: 'נן',
+  צ: 'צץ',
+  ץ: 'צץ',
+  פ: 'פף',
+  ף: 'פף',
+  כ: 'כך',
+  ך: 'כך',
+}
+
+export interface ProximityQuery {
+  distance: number
+  patterns: string[]
+  regexes: RegExp[]
+}
+
+export interface ProximityMatchWord {
+  wordIndex: number
+  word: string
+  charStart: number
+  charEnd: number
+  patternIndex: number
+}
+
+export interface ProximityMatch {
+  words: ProximityMatchWord[]
+  charStart: number
+  charEnd: number
+}
+
+const DEFAULT_PROXIMITY_DISTANCE = 10
+// N optional: @10(...) or @(...)
+const PROXIMITY_QUERY_REGEX = /^@(\d*)\s*\(([^)]*)\)\s*$/
+// RTL-reversed form: )N(pattern@ or )(pattern@
+const PROXIMITY_QUERY_RTL_REGEX = /^\)\s*(\d*)\s*\(([^@)]*)\)?\s*@\s*$/
+
+/**
+ * Normalize query so RTL-typed form )N(pattern@ is converted to @N(pattern).
+ */
+function normalizeProximityQuery(query: string): string {
+  const t = query.trim()
+  const rtl = t.match(PROXIMITY_QUERY_RTL_REGEX)
+  if (rtl) {
+    const n = rtl[1] || ''
+    return `@${n}(${rtl[2].trim()})`
+  }
+  return t
+}
+
+/**
+ * Check if a query string is a proximity query (@N(...), @(...), or RTL form).
+ */
+export function isProximityQuery(query: string): boolean {
+  const t = query.trim()
+  return (
+    (t.startsWith('@') && PROXIMITY_QUERY_REGEX.test(t)) ||
+    PROXIMITY_QUERY_RTL_REGEX.test(t)
+  )
+}
+
+/**
+ * Parse @N(pattern1 pattern2 ...) into structured form.
+ * N is optional; when omitted, default distance is used.
+ * Also accepts RTL form )N(pattern@ and normalizes it first.
+ */
+export function parseProximityQuery(query: string): ProximityQuery {
+  const t = normalizeProximityQuery(query)
+  const m = t.match(PROXIMITY_QUERY_REGEX)
+  if (!m) {
+    throw new Error('Invalid proximity query')
+  }
+  const distance = m[1]
+    ? Math.max(0, parseInt(m[1], 10))
+    : DEFAULT_PROXIMITY_DISTANCE
+  const inner = m[2].trim()
+  const patterns = inner
+    ? inner.split(/\s+/).map(p => p.trim()).filter(Boolean)
+    : []
+  const regexes = patterns.map(patternToRegex)
+  return { distance, patterns, regexes }
+}
+
+/**
+ * Character class for a single Hebrew letter, including final form if any.
+ */
+function letterClass(char: string): string {
+  const pair = FINAL_FORMS[char]
+  if (pair) return `[${pair}]`
+  return char
+}
+
+/**
+ * Compile a wildcard pattern to a RegExp.
+ * * = any Hebrew letter (zero or more)
+ * + = zero or more from prefix/suffix set
+ * Letters get final-form equivalence.
+ */
+export function patternToRegex(pattern: string): RegExp {
+  let re = ''
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i]
+    if (c === '*') {
+      re += `[${HEBREW_LETTERS}]*`
+    } else if (c === '+') {
+      re += `${PLUS_CLASS}*`
+    } else if (c >= '\u05D0' && c <= '\u05EA') {
+      re += letterClass(c)
+    }
+    // Skip any other characters (e.g. spaces already removed)
+  }
+  return new RegExp(`^${re}$`, 'u')
+}
+
+/**
+ * Strip nikud/cantillation from a string.
+ */
+function stripNikud(text: string): string {
+  return text.replace(NIKUD_REGEX, '')
+}
+
+export interface HebrewToken {
+  wordIndex: number
+  word: string
+  normalized: string
+  charStart: number
+  charEnd: number
+}
+
+const HEBREW_TOKEN_REGEX = /[\u05D0-\u05EA\u0591-\u05C7\u05F0-\u05F4]+/gu
+
+/**
+ * Tokenize text into Hebrew words (with nikud stripped for matching).
+ * Returns tokens with indices in the original text.
+ */
+export function tokenizeHebrew(text: string): HebrewToken[] {
+  const tokens: HebrewToken[] = []
+  let match: RegExpExecArray | null
+  const re = new RegExp(HEBREW_TOKEN_REGEX.source, 'gu')
+  let wordIndex = 0
+  while ((match = re.exec(text)) !== null) {
+    const raw = match[0]
+    const normalized = stripNikud(raw)
+    if (normalized.length > 0) {
+      tokens.push({
+        wordIndex,
+        word: raw,
+        normalized,
+        charStart: match.index,
+        charEnd: match.index + raw.length,
+      })
+      wordIndex++
+    }
+  }
+  return tokens
+}
+
+/**
+ * Find all combinations of (one position per pattern) where
+ * max(positions) - min(positions) <= N.
+ * Same word can match multiple patterns (position repeated).
+ */
+function findProximityGroups(
+  positionsByPattern: number[][],
+  maxDist: number
+): number[][] {
+  const n = positionsByPattern.length
+  if (n === 0) return []
+  if (n === 1) {
+    return positionsByPattern[0].map(p => [p])
+  }
+
+  // Sort each pattern's positions
+  const sorted = positionsByPattern.map(positions =>
+    [...positions].sort((a, b) => a - b)
+  )
+
+  const results: number[][] = []
+
+  function backtrack(
+    patternIdx: number,
+    combo: number[],
+    currentMin: number,
+    currentMax: number
+  ) {
+    if (patternIdx === n) {
+      results.push([...combo])
+      return
+    }
+    const positions = sorted[patternIdx]
+    for (const pos of positions) {
+      const newMin = Math.min(currentMin, pos)
+      const newMax = Math.max(currentMax, pos)
+      if (newMax - newMin > maxDist) {
+        if (pos > currentMax) break
+        continue
+      }
+      combo.push(pos)
+      backtrack(patternIdx + 1, combo, newMin, newMax)
+      combo.pop()
+    }
+  }
+
+  const firstPositions = sorted[0]
+  for (const pos of firstPositions) {
+    backtrack(1, [pos], pos, pos)
+  }
+  return results
+}
+
+/**
+ * Run proximity search on document text. Returns match positions in original text.
+ */
+export function proximitySearchText(
+  text: string,
+  query: ProximityQuery
+): ProximityMatch[] {
+  const tokens = tokenizeHebrew(text)
+  if (tokens.length === 0) return []
+
+  const { distance, regexes } = query
+
+  // For each pattern, get word indices that match (using normalized token text)
+  const positionsByPattern: number[][] = regexes.map(() => [])
+  for (let pi = 0; pi < regexes.length; pi++) {
+    const re = regexes[pi]
+    for (const tok of tokens) {
+      if (re.test(tok.normalized)) {
+        positionsByPattern[pi].push(tok.wordIndex)
+      }
+    }
+  }
+
+  // Single pattern: every matching word is a "proximity" match (distance 0)
+  if (regexes.length === 1) {
+    const matches: ProximityMatch[] = []
+    for (const wordIdx of positionsByPattern[0]) {
+      const tok = tokens[wordIdx]
+      matches.push({
+        words: [
+          {
+            wordIndex: wordIdx,
+            word: tok.word,
+            charStart: tok.charStart,
+            charEnd: tok.charEnd,
+            patternIndex: 0,
+          },
+        ],
+        charStart: tok.charStart,
+        charEnd: tok.charEnd,
+      })
+    }
+    return matches
+  }
+
+  const groups = findProximityGroups(positionsByPattern, distance)
+  const matches: ProximityMatch[] = []
+
+  for (const combo of groups) {
+    const wordIndices = combo
+    const wordTokens = wordIndices.map(idx => tokens[idx])
+    const charStart = Math.min(...wordTokens.map(t => t.charStart))
+    const charEnd = Math.max(...wordTokens.map(t => t.charEnd))
+    const words: ProximityMatchWord[] = wordIndices.map((wordIdx, i) => {
+      const tok = tokens[wordIdx]
+      return {
+        wordIndex: wordIdx,
+        word: tok.word,
+        charStart: tok.charStart,
+        charEnd: tok.charEnd,
+        patternIndex: i,
+      }
+    })
+    matches.push({ words, charStart, charEnd })
+  }
+
+  return matches
+}
+
+/**
+ * Convert ProximityMatch[] to Omnisearch SearchMatch[] (match string + offset).
+ * We flatten to one SearchMatch per matched word span so highlighting works.
+ */
+export function proximityMatchesToSearchMatches(
+  matches: ProximityMatch[]
+): SearchMatch[] {
+  const seen = new Set<string>()
+  const result: SearchMatch[] = []
+  for (const pm of matches) {
+    for (const w of pm.words) {
+      const key = `${w.charStart}:${w.charEnd}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      result.push({
+        match: w.word,
+        offset: w.charStart,
+      })
+    }
+  }
+  return result
+}
+
+/**
+ * Extract root Hebrew letters from patterns (strip * and +) for MiniSearch pre-filtering.
+ * E.g. "+ת*ק*ן+" → "תקן"
+ */
+export function extractRootTerms(patterns: string[]): string[] {
+  const roots: string[] = []
+  for (const p of patterns) {
+    const letters = p.replace(/[*+]/g, '')
+    if (letters.length > 0) roots.push(letters)
+  }
+  return [...new Set(roots)]
+}

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -1,5 +1,11 @@
 import { removeDiacritics } from '../tools/utils'
 import { parse } from 'search-query-parser'
+import {
+  isProximityQuery,
+  parseProximityQuery,
+  extractRootTerms,
+  type ProximityQuery,
+} from './proximity-search'
 
 const keywords = ['ext', 'path'] as const
 
@@ -12,10 +18,25 @@ export class Query {
     exclude: Keywords
   }
   #inQuotes: string[]
+  /** Set when the query is a proximity query @N(pattern1 pattern2 ...) */
+  public proximityQuery: ProximityQuery | null = null
 
   constructor(text = '', options: { ignoreDiacritics: boolean, ignoreArabicDiacritics: boolean}) {
     if (options.ignoreDiacritics) {
       text = removeDiacritics(text, options.ignoreArabicDiacritics)
+    }
+    const trimmed = text.trim()
+    if (isProximityQuery(trimmed)) {
+      this.proximityQuery = parseProximityQuery(text)
+      const rootTerms = extractRootTerms(this.proximityQuery.patterns)
+      this.query = {
+        text: rootTerms,
+        exclude: { text: [] },
+        ext: [],
+        path: [],
+      }
+      this.#inQuotes = []
+      return
     }
     const parsed = parse(text.toLowerCase(), {
       tokenize: true,
@@ -60,6 +81,9 @@ export class Query {
   }
 
   public isEmpty(): boolean {
+    if (this.proximityQuery !== null) {
+      return this.proximityQuery.patterns.length === 0
+    }
     for (const k of keywords) {
       if (this.query[k]?.length) {
         return false

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -21,6 +21,10 @@ import type { Query } from './query'
 import { sortBy } from 'lodash-es'
 import type OmnisearchPlugin from '../main'
 import { Tokenizer } from './tokenizer'
+import {
+  proximitySearchText,
+  proximityMatchesToSearchMatches,
+} from './proximity-search'
 
 export class SearchEngine {
   private tokenizer: Tokenizer
@@ -397,6 +401,13 @@ export class SearchEngine {
     query: Query,
     options?: Partial<{ singleFilePath?: string }>
   ): Promise<ResultNote[]> {
+    // Proximity queries: scan indexed documents directly instead of relying
+    // on MiniSearch, because Hebrew prefix letters (ב,ה,ו,ל,...) make root
+    // terms unreliable for MiniSearch token matching.
+    if (query.proximityQuery) {
+      return this.getProximitySuggestions(query, options)
+    }
+
     // Get the raw results
     let results: SearchResult[]
     if (this.plugin.settings.simpleSearch) {
@@ -489,6 +500,47 @@ export class SearchEngine {
 
     logVerbose('Suggestions:', resultNotes)
 
+    return resultNotes
+  }
+
+  /**
+   * Proximity queries: scan all indexed documents directly and return
+   * only those that have proximity matches. Bypasses MiniSearch because
+   * Hebrew prefix letters make root-term matching unreliable.
+   */
+  private async getProximitySuggestions(
+    query: Query,
+    options?: Partial<{ singleFilePath?: string }>
+  ): Promise<ResultNote[]> {
+    const proxQuery = query.proximityQuery!
+    let paths = [...this.indexedDocuments.keys()]
+    if (options?.singleFilePath) {
+      paths = paths.filter(p => p === options.singleFilePath)
+    }
+
+    logVerbose(`Proximity search: scanning ${paths.length} documents`)
+
+    const resultNotes: ResultNote[] = []
+    for (const path of paths) {
+      const doc = await this.plugin.documentsRepository.getDocument(path)
+      if (!doc?.content) continue
+
+      const proxMatches = proximitySearchText(doc.content, proxQuery)
+      if (proxMatches.length === 0) continue
+
+      const matches = proximityMatchesToSearchMatches(proxMatches)
+      resultNotes.push({
+        score: proxMatches.length,
+        foundWords: proxQuery.patterns,
+        matches,
+        isEmbed: false,
+        ...doc,
+      })
+      if (resultNotes.length >= 50) break
+    }
+
+    resultNotes.sort((a, b) => b.score - a.score)
+    logVerbose(`Proximity search: found ${resultNotes.length} results`)
     return resultNotes
   }
 

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -459,31 +459,27 @@ export class SearchEngine {
         } as IndexedDocument
       }
 
-      // Clean search matches that match quoted expressions,
-      // and inject those expressions instead
+      // Use the user's actual query terms for highlighting, not MiniSearch's
+      // result.terms (which can include fuzzy matches like "תקיש" for "תקון").
+      // This way we only highlight what the user searched for.
       const foundWords = [
-        // Matching terms from the result,
-        // do not necessarily match the query
-        ...result.terms,
-
-        // Quoted expressions
+        ...query.query.text,
         ...query.getExactTerms(),
-
-        // Tags, starting with #
         ...query.getTags(),
-      ]
-      logVerbose('Matching tokens:', foundWords)
+      ].filter(Boolean)
+      const uniqueFoundWords = [...new Set(foundWords)]
+      logVerbose('Matching tokens (query terms for highlight):', uniqueFoundWords)
 
       logVerbose('Getting matches locations...')
       const matches = this.plugin.textProcessor.getMatches(
         note.content,
-        foundWords,
+        uniqueFoundWords,
         query
       )
       logVerbose(`Matches for note "${note.path}"`, matches)
       const resultNote: ResultNote = {
         score: result.score,
-        foundWords,
+        foundWords: uniqueFoundWords,
         matches,
         isEmbed: result.isEmbed,
         ...note,

--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -7,10 +7,11 @@ import type OmnisearchPlugin from '../main'
 
 // When matching with "ignore diacritics", allow these between base letters so we
 // search the original text and get correct indices (normalized text has different length).
+// Exclude U+05BE (maqaf ־) — it's a hyphen, not a diacritic.
 const OPTIONAL_DIACRITICS_CLASS =
-  '[\\u0591-\\u05C7\\u0300-\\u036f]' // Hebrew nikud + Latin combining
+  '[\\u0591-\\u05BD\\u05BF-\\u05C7\\u0300-\\u036f]' // Hebrew nikud + Latin combining
 const OPTIONAL_DIACRITICS_CLASS_ARABIC =
-  '[\\u0591-\\u05C7\\u0300-\\u036f\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7\\u06E8\\u06EA-\\u06ED]'
+  '[\\u0591-\\u05BD\\u05BF-\\u05C7\\u0300-\\u036f\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7\\u06E8\\u06EA-\\u06ED]'
 
 export class TextProcessor {
   constructor(private plugin: OmnisearchPlugin) {}
@@ -105,7 +106,9 @@ export class TextProcessor {
         .map(w => this.regexForWordWithOptionalDiacritics(w, arabic))
         .filter(Boolean)
       if (!patterns.length) return []
-      const joined = `(?:${patterns.map(p => `\\b(?:${p})\\b|(?:${p})`).join('|')})`
+      // Don't use \b word boundaries — they're unreliable with Hebrew in many engines.
+      // Match the pattern (word + optional diacritics) anywhere; prefix matches still work.
+      const joined = `(?:${patterns.map(p => `(?:${p})`).join('|')})`
       reg = new RegExp(joined, 'giu')
       searchText = originalText
     } else {

--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -5,6 +5,13 @@ import { Notice } from 'obsidian'
 import { escapeRegExp } from 'lodash-es'
 import type OmnisearchPlugin from '../main'
 
+// When matching with "ignore diacritics", allow these between base letters so we
+// search the original text and get correct indices (normalized text has different length).
+const OPTIONAL_DIACRITICS_CLASS =
+  '[\\u0591-\\u05C7\\u0300-\\u036f]' // Hebrew nikud + Latin combining
+const OPTIONAL_DIACRITICS_CLASS_ARABIC =
+  '[\\u0591-\\u05C7\\u0300-\\u036f\\u0610-\\u061A\\u064B-\\u065F\\u0670\\u06D6-\\u06DC\\u06DF-\\u06E4\\u06E7\\u06E8\\u06EA-\\u06ED]'
+
 export class TextProcessor {
   constructor(private plugin: OmnisearchPlugin) {}
 
@@ -54,6 +61,24 @@ export class TextProcessor {
   }
 
   /**
+   * Builds a regex pattern that matches a word with optional diacritics between
+   * each character. Used on the *original* text so match indices are correct
+   * (normalized text has different length and would give wrong highlight spans).
+   */
+  private regexForWordWithOptionalDiacritics(
+    word: string,
+    arabic: boolean
+  ): string {
+    const diacriticsClass = arabic
+      ? OPTIONAL_DIACRITICS_CLASS_ARABIC
+      : OPTIONAL_DIACRITICS_CLASS
+    const opt = `(?:${diacriticsClass})*`
+    const chars = [...word].map(c => escapeRegExp(c))
+    if (chars.length === 0) return ''
+    return chars.join(opt) + opt
+  }
+
+  /**
    * Returns an array of matches in the text, using the provided regex
    * @param text
    * @param reg
@@ -65,27 +90,39 @@ export class TextProcessor {
     query?: Query
   ): SearchMatch[] {
     words = words.map(escapeHTML)
-    const reg = this.stringsToRegex(words)
     const originalText = text
-    // text = text.toLowerCase().replace(new RegExp(SEPARATORS, 'gu'), ' ')
-    if (this.plugin.settings.ignoreDiacritics) {
-      text = removeDiacritics(text, this.plugin.settings.ignoreArabicDiacritics)
+    const ignoreDiacritics = this.plugin.settings.ignoreDiacritics
+    const arabic = this.plugin.settings.ignoreArabicDiacritics
+
+    let reg: RegExp
+    let searchText: string
+
+    if (ignoreDiacritics) {
+      // Match on original text with optional diacritics between letters so
+      // indices and matched strings are correct (normalized text has different length).
+      const sorted = [...words].sort((a, b) => b.length - a.length)
+      const patterns = sorted
+        .map(w => this.regexForWordWithOptionalDiacritics(w, arabic))
+        .filter(Boolean)
+      if (!patterns.length) return []
+      const joined = `(?:${patterns.map(p => `\\b(?:${p})\\b|(?:${p})`).join('|')})`
+      reg = new RegExp(joined, 'giu')
+      searchText = originalText
+    } else {
+      reg = this.stringsToRegex(words)
+      searchText = originalText
     }
+
     const startTime = new Date().getTime()
     let match: RegExpExecArray | null = null
     let matches: SearchMatch[] = []
     let count = 0
-    while ((match = reg.exec(text)) !== null) {
-      // Avoid infinite loops, stop looking after 100 matches or if we're taking too much time
+    while ((match = reg.exec(searchText)) !== null) {
       if (++count >= 100 || new Date().getTime() - startTime > 50) {
         warnVerbose('Stopped getMatches at', count, 'results')
         break
       }
-      const matchStartIndex = match.index
-      const matchEndIndex = matchStartIndex + match[0].length
-      const originalMatch = originalText
-        .substring(matchStartIndex, matchEndIndex)
-        .trim()
+      const originalMatch = match[0].trim()
       if (originalMatch && match.index >= 0) {
         matches.push({ match: originalMatch, offset: match.index })
       }
@@ -96,12 +133,18 @@ export class TextProcessor {
       query &&
       (query.query.text.length > 1 || query.getExactTerms().length > 0)
     ) {
-      const best = text.indexOf(query.getBestStringForExcerpt())
-      if (best > -1 && matches.find(m => m.offset === best)) {
-        matches.unshift({
-          offset: best,
-          match: query.getBestStringForExcerpt(),
-        })
+      const bestStr = query.getBestStringForExcerpt()
+      const bestMatch = matches.find(m => {
+        const normalized = ignoreDiacritics
+          ? removeDiacritics(m.match, arabic)
+          : m.match
+        return normalized.toLowerCase() === bestStr.toLowerCase()
+      })
+      if (bestMatch) {
+        matches = [
+          bestMatch,
+          ...matches.filter(m => m !== bestMatch),
+        ]
       }
     }
     return matches

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -111,8 +111,8 @@ export function getTagsFromMetadata(metadata: CachedMetadata | null): string[] {
 const japaneseDiacritics = ['\\u30FC', '\\u309A', '\\u3099']
 const regexpExclude = japaneseDiacritics.join('|')
 const diacriticsRegex = new RegExp(`(?!${regexpExclude})\\p{Diacritic}`, 'gu')
-// Hebrew nikud (vowels, dagesh, cantillation): U+0591–U+05C7
-const hebrewNikudRegex = /[\u0591-\u05C7]/g
+// Hebrew nikud (vowels, dagesh, cantillation): U+0591–U+05C7, excluding U+05BE (maqaf ־ hyphen)
+const hebrewNikudRegex = /[\u0591-\u05BD\u05BF-\u05C7]/g
 // Arabic harakat and small marks (only used when ignoreArabicDiacritics is on)
 const arabicHarakatRegex = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED]/g
 

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -111,6 +111,10 @@ export function getTagsFromMetadata(metadata: CachedMetadata | null): string[] {
 const japaneseDiacritics = ['\\u30FC', '\\u309A', '\\u3099']
 const regexpExclude = japaneseDiacritics.join('|')
 const diacriticsRegex = new RegExp(`(?!${regexpExclude})\\p{Diacritic}`, 'gu')
+// Hebrew nikud (vowels, dagesh, cantillation): U+0591–U+05C7
+const hebrewNikudRegex = /[\u0591-\u05C7]/g
+// Arabic harakat and small marks (only used when ignoreArabicDiacritics is on)
+const arabicHarakatRegex = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED]/g
 
 /**
  * https://stackoverflow.com/a/37511463
@@ -140,7 +144,12 @@ export function removeDiacritics(str: string, arabic = false): string {
   // Keep caret same as above
   str = str.replaceAll('^', '[__omnisearch__caret__]')
   // To keep right form of Korean character, NFC normalization is necessary
-  str = str.normalize('NFD').replace(diacriticsRegex, '').normalize('NFC')
+  // \p{Diacritic} covers Latin combining marks; Hebrew nikud and Arabic harakat need explicit ranges
+  str = str.normalize('NFD').replace(diacriticsRegex, '').replace(hebrewNikudRegex, '')
+  if (arabic) {
+    str = str.replace(arabicHarakatRegex, '')
+  }
+  str = str.normalize('NFC')
   str = str.replaceAll('[__omnisearch__backtick__]', '`')
   str = str.replaceAll('[__omnisearch__caret__]', '^')
   return str


### PR DESCRIPTION
## Summary

- Adds a new `@N(pattern1 pattern2 ...)` search syntax that finds Hebrew words matching wildcard patterns within N words of each other (N is optional, defaults to 10)
- Supports `*` (any Hebrew letter), `+` (prefix/suffix letter set), final-form interchangeability (e.g. מ/ם, נ/ן), and automatic nikud stripping
- Scans all indexed documents directly for proximity queries, bypassing MiniSearch pre-filtering (Hebrew prefix letters make token-based pre-filtering unreliable)
- Handles both LTR (`@10(תקון)`) and RTL (`)10(תקון@`) input forms

### Files changed

| File | Action |
|------|--------|
| `src/search/proximity-search.ts` | **Created** — core proximity search logic (parsing, regex compilation, tokenizer, proximity window finder, match conversion) |
| `src/search/query.ts` | **Modified** — detect `@N(...)` syntax early in the Query constructor, store parsed ProximityQuery, populate root terms for downstream use |
| `src/search/search-engine.ts` | **Modified** — added `getProximitySuggestions()` that scans all indexed documents with proximity matching, called from `getSuggestions()` when a proximity query is detected |
| `src/__tests__/proximity-search-tests.ts` | **Created** — unit tests for parsing, regex compilation, tokenization, proximity matching, and root term extraction |

## Test plan

- [ ] Open Omnisearch (Vault search) and enter `@10(תקון)` — should return notes containing the Hebrew word תקון (and variants like תִּקּוּן with nikud)
- [ ] Verify highlighting works on matched words in the result excerpts
- [ ] Test multi-pattern query `@10(+ת*ק*ן+ +ש+למ+ מאד)` — should find documents where all three patterns appear within 10 Hebrew words of each other
- [ ] Test single-pattern query `@(+תקן+)` (no distance number) — should default to distance 10
- [ ] Test RTL input form `)10(תקון@` — should be recognized and work identically
- [ ] Verify that normal (non-proximity) searches are completely unaffected
- [ ] Run existing test suite to confirm no regressions