### PR TITLE
Fix: Skip excluded files during indexing when hideExcluded is enabled

### DIFF
--- a/src/notes-indexer.ts
+++ b/src/notes-indexer.ts
@@ -39,6 +39,15 @@ export class NotesIndexer {
   }
 
   public isFileIndexable(path: string): boolean {
+    // Skip excluded files when hideExcluded is enabled
+    if (
+      this.plugin.settings.hideExcluded &&
+      this.plugin.app.metadataCache.isUserIgnored &&
+      this.plugin.app.metadataCache.isUserIgnored(path)
+    ) {
+      return false
+    }
+
     return this.isFilenameIndexable(path) || this.isContentIndexable(path)
   }
 


### PR DESCRIPTION
## Description
Fixes performance issue where excluded files were being indexed then filtered from results, causing slow startup.

## Changes
- Modified `isFileIndexable()` in `src/notes-indexer.ts` to check `isUserIgnored()` before indexing
- Files matching Obsidian's `userIgnoreFilters` are now skipped during indexing when `hideExcluded` setting is enabled

## Performance Impact
Tested on a vault with ~258,000 files total (~7,400 .md files ~256,000 files of other types):
- **Before:** ~7,400 files indexed in 15.7 seconds
- **After:** ~1,500 files indexed in 6.6 seconds
- **Result:** ~ 80% fewer files indexed, 58% faster startup

## Notes
This improves the existing `hideExcluded` setting. Issue #504 proposes an additional feature for Omnisearch-specific exclusions, which could be implemented separately.