### PR TITLE
feat: Highlight search result on open with cursor at match start

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -63,7 +63,6 @@
   margin-left: 1em;
 }
 
-
 .omnisearch-result__image-container {
   flex-basis: 20%;
   text-align: end;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -132,3 +132,19 @@
   position: relative;
   flex-grow: 1;
 }
+
+.omnisearch-result-highlight .cm-content ::selection,
+.omnisearch-result-highlight .cm-line::selection {
+  background-color: var(
+    --omnisearch-highlight-color,
+    rgba(222, 183, 110, 1)
+  ) !important;
+  color: var(--omnisearch-highlight-text-color, black) !important;
+}
+
+.omnisearch-result-highlight .cm-selectionLayer .cm-selectionBackground {
+  background-color: var(
+    --omnisearch-highlight-color,
+    rgba(222, 183, 110, 1)
+  ) !important;
+}

--- a/src/components/ModalInFile.svelte
+++ b/src/components/ModalInFile.svelte
@@ -134,12 +134,7 @@
 
       // Open (or switch focus to) the note
       const offset = groupedOffsets[selectedIndex] ?? 0
-
-      // Find the match at this offset
-      const currentMatch = note.matches?.find(m => m.offset === offset)
-      const matchLen = currentMatch?.match.length ?? 0
-
-      await openNote(plugin, note, offset, newTab, false, matchLen)
+      await openNote(plugin, note, offset, newTab)
     }
   }
 

--- a/src/components/ModalInFile.svelte
+++ b/src/components/ModalInFile.svelte
@@ -133,26 +133,13 @@
       if (parent) parent.close()
 
       // Open (or switch focus to) the note
-      const reg = plugin.textProcessor.stringsToRegex(note.foundWords)
-      reg.exec(note.content)
-      await openNote(plugin, note, reg.lastIndex, newTab)
-
-      // Move cursor to the match
-      const view = plugin.app.workspace.getActiveViewOfType(MarkdownView)
-      if (!view) {
-        // Not an editable document, so no cursor to place
-        return
-        // throw new Error('OmniSearch - No active MarkdownView')
-      }
-
       const offset = groupedOffsets[selectedIndex] ?? 0
-      const pos = view.editor.offsetToPos(offset)
-      pos.ch = 0
-      view.editor.setCursor(pos)
-      view.editor.scrollIntoView({
-        from: { line: pos.line - 10, ch: 0 },
-        to: { line: pos.line + 10, ch: 0 },
-      })
+
+      // Find the match at this offset
+      const currentMatch = note.matches?.find(m => m.offset === offset)
+      const matchLen = currentMatch?.match.length ?? 0
+
+      await openNote(plugin, note, offset, newTab, false, matchLen)
     }
   }
 

--- a/src/components/ModalInFile.svelte
+++ b/src/components/ModalInFile.svelte
@@ -9,7 +9,7 @@
   } from '../globals'
   import { getCtrlKeyLabel, loopIndex } from '../tools/utils'
   import { onDestroy, onMount, tick } from 'svelte'
-  import { MarkdownView, Platform } from 'obsidian'
+  import { Platform } from 'obsidian'
   import ModalContainer from './ModalContainer.svelte'
   import {
     OmnisearchInFileModal,

--- a/src/components/ModalInFile.svelte
+++ b/src/components/ModalInFile.svelte
@@ -145,13 +145,13 @@
 </script>
 
 <InputSearch
-  plugin="{plugin}"
-  on:input="{e => (searchQuery = e.detail)}"
+  {plugin}
+  on:input={e => (searchQuery = e.detail)}
   placeholder="Omnisearch - File"
-  initialValue="{previousQuery}">
+  initialValue={previousQuery}>
   <div class="omnisearch-input-container__buttons">
     {#if Platform.isMobile}
-      <button on:click="{switchToVaultModal}">Vault search</button>
+      <button on:click={switchToVaultModal}>Vault search</button>
     {/if}
   </div>
 </InputSearch>
@@ -161,15 +161,15 @@
     {#each groupedOffsets as offset, i}
       <ResultItemInFile
         {plugin}
-        offset="{offset}"
-        note="{note}"
-        index="{i}"
-        selected="{i === selectedIndex}"
-        on:mousemove="{_e => (selectedIndex = i)}"
-        on:click="{evt => openSelection(evt.ctrlKey)}"
-        on:auxclick="{evt => {
+        {offset}
+        {note}
+        index={i}
+        selected={i === selectedIndex}
+        on:mousemove={_e => (selectedIndex = i)}
+        on:click={evt => openSelection(evt.ctrlKey)}
+        on:auxclick={evt => {
           if (evt.button == 1) openSelection(true)
-        }}" />
+        }} />
     {/each}
   {:else}
     <div style="text-align: center;">

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -211,8 +211,10 @@
     newLeaf = false
   ) {
     saveCurrentQuery()
-    const offset = note.matches?.[0]?.offset ?? 0
-    openNote(plugin, note, offset, newPane, newLeaf)
+    const firstMatch = note.matches?.[0]
+    const offset = firstMatch?.offset ?? 0
+    const matchLen = firstMatch?.match.length ?? 0
+    openNote(plugin, note, offset, newPane, newLeaf, matchLen)
   }
 
   async function onClickCreateNote(_e: MouseEvent) {

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -211,10 +211,8 @@
     newLeaf = false
   ) {
     saveCurrentQuery()
-    const firstMatch = note.matches?.[0]
-    const offset = firstMatch?.offset ?? 0
-    const matchLen = firstMatch?.match.length ?? 0
-    openNote(plugin, note, offset, newPane, newLeaf, matchLen)
+    const offset = note.matches?.[0]?.offset ?? 0
+    openNote(plugin, note, offset, newPane, newLeaf)
   }
 
   async function onClickCreateNote(_e: MouseEvent) {

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -126,7 +126,7 @@ export async function openNote(
     view.editor.setSelection(endPos, pos)
 
     // Inject pink highlight style directly into the document
-    const styleId = 'omnisearch-result-highlight-style'
+    const styleId = 'omnisearch-rh-style'
     if (!document.getElementById(styleId)) {
       const style = document.createElement('style')
       style.id = styleId
@@ -134,6 +134,7 @@ export async function openNote(
         .omnisearch-result-highlight .cm-content ::selection,
         .omnisearch-result-highlight .cm-line::selection {
           background-color: var(--omnisearch-highlight-color, hotpink) !important;
+          color: var(--omnisearch-highlight-text-color, black) !important;
         }
         .omnisearch-result-highlight .cm-selectionLayer .cm-selectionBackground {
           background-color: var(--omnisearch-highlight-color, hotpink) !important;

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -1,4 +1,10 @@
-import { type App, type CachedMetadata, MarkdownView, TFile, WorkspaceLeaf } from 'obsidian'
+import {
+  type App,
+  type CachedMetadata,
+  MarkdownView,
+  TFile,
+  WorkspaceLeaf,
+} from 'obsidian'
 import OmnisearchPlugin from '../main'
 import type { ResultNote } from '../globals'
 
@@ -16,9 +22,7 @@ function getPdfPageFromOffset(content: string, offset: number): number | null {
   const regex = /^# Page ([0-9]+)\^page=\1$/gm
   let lastMatch: RegExpExecArray | null = null
   let match: RegExpExecArray | null
-  while (
-    (match = regex.exec(textBeforeOffset)) !== null
-  ) {
+  while ((match = regex.exec(textBeforeOffset)) !== null) {
     lastMatch = match
   }
 
@@ -33,7 +37,7 @@ export async function openNote(
   newPane = false,
   newLeaf = false
 ): Promise<void> {
-  const app = plugin.app;
+  const app = plugin.app
   // We don't have a way to switch pages on a PDF view, so we must open a new pane for PDF results to trigger page navigation
   // We should only trigger this behaviour if we know the page number for the result
   // This code runs before the normal implementation because we don't want to trigger activation of an existing pane for this PDF and then open a new one on top
@@ -94,7 +98,11 @@ export async function openNote(
       const leaf = app.workspace.getLeaf(newLeaf ? 'split' : newPane)
       await leaf.openFile(existingFile, { active: !newLeaf && !newPane })
     } else {
-      await app.workspace.openLinkText(item.path, '', newLeaf ? 'split' : newPane)
+      await app.workspace.openLinkText(
+        item.path,
+        '',
+        newLeaf ? 'split' : newPane
+      )
     }
   }
 
@@ -105,9 +113,15 @@ export async function openNote(
     return
   }
   const pos = view.editor.offsetToPos(offset)
-  // pos.ch = 0
 
-  view.editor.setCursor(pos)
+  // Find the match at this offset, if any, to highlight the matched text
+  const match = item.matches?.find(m => m.offset === offset)
+  if (match) {
+    const endPos = view.editor.offsetToPos(offset + match.match.length)
+    view.editor.setSelection(pos, endPos)
+  } else {
+    view.editor.setCursor(pos)
+  }
   view.editor.scrollIntoView({
     from: { line: pos.line - 10, ch: 0 },
     to: { line: pos.line + 10, ch: 0 },

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -118,7 +118,8 @@ export async function openNote(
   const match = item.matches?.find(m => m.offset === offset)
   if (match) {
     const endPos = view.editor.offsetToPos(offset + match.match.length)
-    view.editor.setSelection(pos, endPos)
+    // setSelection(anchor, head): cursor goes to head → ставим в начало
+    view.editor.setSelection(endPos, pos)
   } else {
     view.editor.setCursor(pos)
   }

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -125,24 +125,6 @@ export async function openNote(
     const endPos = view.editor.offsetToPos(offset + match.match.length)
     view.editor.setSelection(endPos, pos)
 
-    // Inject pink highlight style directly into the document
-    const styleId = 'omnisearch-rh-style'
-    if (!document.getElementById(styleId)) {
-      const style = document.createElement('style')
-      style.id = styleId
-      style.textContent = `
-        .omnisearch-result-highlight .cm-content ::selection,
-        .omnisearch-result-highlight .cm-line::selection {
-          background-color: var(--omnisearch-highlight-color, rgba(222, 183, 110, 1.0)) !important;
-          color: var(--omnisearch-highlight-text-color, black) !important;
-        }
-        .omnisearch-result-highlight .cm-selectionLayer .cm-selectionBackground {
-          background-color: var(--omnisearch-highlight-color, rgba(222, 183, 110, 1.0)) !important;
-        }
-      `
-      document.head.appendChild(style)
-    }
-
     // Find .cm-editor reliably through the view's content area
     const cmEditor =
       view.contentEl?.querySelector('.cm-editor') ??

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -113,20 +113,52 @@ export async function openNote(
     return
   }
   const pos = view.editor.offsetToPos(offset)
+  view.editor.setCursor(pos)
+  view.editor.scrollIntoView({
+    from: { line: Math.max(0, pos.line - 10), ch: 0 },
+    to: { line: pos.line + 10, ch: 0 },
+  })
 
-  // Find the match at this offset, if any, to highlight the matched text
+  // Highlight the match with a pink selection (like Ctrl+F)
   const match = item.matches?.find(m => m.offset === offset)
   if (match) {
     const endPos = view.editor.offsetToPos(offset + match.match.length)
-    // setSelection(anchor, head): cursor goes to head → ставим в начало
     view.editor.setSelection(endPos, pos)
-  } else {
-    view.editor.setCursor(pos)
+
+    // Inject pink highlight style directly into the document
+    const styleId = 'omnisearch-result-highlight-style'
+    if (!document.getElementById(styleId)) {
+      const style = document.createElement('style')
+      style.id = styleId
+      style.textContent = `
+        .omnisearch-result-highlight .cm-content ::selection,
+        .omnisearch-result-highlight .cm-line::selection {
+          background-color: var(--omnisearch-highlight-color, hotpink) !important;
+        }
+        .omnisearch-result-highlight .cm-selectionLayer .cm-selectionBackground {
+          background-color: var(--omnisearch-highlight-color, hotpink) !important;
+          opacity: 0.5 !important;
+        }
+      `
+      document.head.appendChild(style)
+    }
+
+    // Find .cm-editor reliably through the view's content area
+    const cmEditor =
+      view.contentEl?.querySelector('.cm-editor') ??
+      view.containerEl?.querySelector('.cm-editor') ??
+      document.querySelector('.cm-editor')
+    if (cmEditor) {
+      cmEditor.classList.add('omnisearch-result-highlight')
+      const cleanup = () => {
+        cmEditor.classList.remove('omnisearch-result-highlight')
+        cmEditor.removeEventListener('mousedown', cleanup)
+        cmEditor.removeEventListener('keydown', cleanup)
+      }
+      cmEditor.addEventListener('mousedown', cleanup)
+      cmEditor.addEventListener('keydown', cleanup)
+    }
   }
-  view.editor.scrollIntoView({
-    from: { line: pos.line - 10, ch: 0 },
-    to: { line: pos.line + 10, ch: 0 },
-  })
 }
 
 export async function createNote(

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -133,12 +133,11 @@ export async function openNote(
       style.textContent = `
         .omnisearch-result-highlight .cm-content ::selection,
         .omnisearch-result-highlight .cm-line::selection {
-          background-color: var(--omnisearch-highlight-color, hotpink) !important;
+          background-color: var(--omnisearch-highlight-color, rgba(222, 183, 110, 1.0)) !important;
           color: var(--omnisearch-highlight-text-color, black) !important;
         }
         .omnisearch-result-highlight .cm-selectionLayer .cm-selectionBackground {
-          background-color: var(--omnisearch-highlight-color, hotpink) !important;
-          opacity: 0.5 !important;
+          background-color: var(--omnisearch-highlight-color, rgba(222, 183, 110, 1.0)) !important;
         }
       `
       document.head.appendChild(style)


### PR DESCRIPTION

## Highlight search result on open with cursor at match start

### Problem
When clicking a search result in Omnisearch, the file opens but:
- The cursor lands at the end of the match instead of the beginning
- There is no visual highlight — the user has to manually scroll and search for where the match is
- In in-file search (`ModalInFile`), `openNote` was called with `reg.lastIndex` (the last position of a RegExp exec) instead of the actual selected match offset, causing incorrect cursor positioning

### Changes

**Cursor placement** (`src/tools/notes.ts`):
- Use `editor.setSelection(endPos, pos)` — `head` at the start of the match, `anchor` at the end — so the cursor lands at the **beginning** of the matched text
- Keep `setCursor(pos)` as a baseline and `scrollIntoView` to bring the match into view

**Visual highlight** (`src/tools/notes.ts`):
- Inject a dynamic `<style>` that overrides the CM6 selection background and `::selection` color
- Default highlight color: `rgba(222, 183, 110, 1.0)` (warm gold), customizable via `--omnisearch-highlight-color`
- Text color inside highlight: `black`, customizable via `--omnisearch-highlight-text-color`
- A temporary class `omnisearch-result-highlight` is added to the `.cm-editor` element and removed on the first user interaction (mousedown/keydown)

### Result
#### Before 

<img width="799" height="330" alt="Screenshot from 2026-04-25 02-07-39" src="https://github.com/user-attachments/assets/81d69250-4950-493b-a4c0-168b6d543a3e" />

#### After


<img width="799" height="330" alt="image" src="https://github.com/user-attachments/assets/fe74399f-71ca-4ffe-be6e-d7484145245b" />

<img width="799" height="330" alt="Screenshot from 2026-04-25 01-27-46" src="https://github.com/user-attachments/assets/f9ea73bb-872d-4686-95d6-4b60cf70f7b7" />




***

**Bug fix** (`src/components/ModalInFile.svelte`):
- Removed redundant cursor positioning that duplicated `openNote`'s internal logic
- Fixed the offset passed to `openNote`: previously used `reg.lastIndex` from `stringsToRegex`, now uses the correct `groupedOffsets[selectedIndex]`
