### PR TITLE
feat: insert link into selected text and frontmatter property (#425, #443)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -82,7 +82,9 @@ module.exports = {
   ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    '^obsidian$': '<rootDir>/src/__mocks__/obsidian.ts',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/src/__mocks__/obsidian.ts
+++ b/src/__mocks__/obsidian.ts
@@ -1,0 +1,54 @@
+// Minimal Obsidian module mock for Jest. Only the symbols our code references
+// at runtime need real values; types are erased.
+
+export const Platform = {
+  isMacOS: false,
+  isMobile: false,
+  isDesktop: true,
+  isDesktopApp: true,
+}
+
+export function getAllTags(meta: any): string[] | null {
+  if (!meta) return null
+  const out: string[] = []
+  if (Array.isArray(meta.tags)) {
+    for (const t of meta.tags) {
+      if (typeof t === 'string') out.push(t.startsWith('#') ? t : `#${t}`)
+      else if (t && typeof t.tag === 'string') out.push(t.tag)
+    }
+  }
+  if (meta.frontmatter?.tags) {
+    const fmTags = Array.isArray(meta.frontmatter.tags)
+      ? meta.frontmatter.tags
+      : [meta.frontmatter.tags]
+    for (const t of fmTags) out.push(t.startsWith('#') ? t : `#${t}`)
+  }
+  return out
+}
+
+export function parseFrontMatterAliases(fm: any): string[] | null {
+  if (!fm) return null
+  const a = fm.aliases ?? fm.alias
+  if (!a) return null
+  return Array.isArray(a) ? a : [a]
+}
+
+export class Modal {}
+export class FuzzySuggestModal {}
+export class Notice {
+  constructor(_msg: string, _ms?: number) {}
+}
+export class TFile {}
+export class MarkdownView {}
+export class Setting {
+  constructor(_el: any) {}
+  setName(_n: string) {
+    return this
+  }
+  addText(_cb: any) {
+    return this
+  }
+  addButton(_cb: any) {
+    return this
+  }
+}

--- a/src/__tests__/link-insertion-tests.ts
+++ b/src/__tests__/link-insertion-tests.ts
@@ -1,0 +1,84 @@
+import { applyLinkToProperty, orderSelection } from '../tools/link-insertion'
+
+describe('orderSelection', () => {
+  it('returns the input order when anchor is already before head', () => {
+    const r = orderSelection({ line: 0, ch: 5 }, { line: 0, ch: 10 })
+    expect(r.from).toEqual({ line: 0, ch: 5 })
+    expect(r.to).toEqual({ line: 0, ch: 10 })
+  })
+
+  it('swaps when the user dragged backwards on a single line', () => {
+    const r = orderSelection({ line: 0, ch: 10 }, { line: 0, ch: 5 })
+    expect(r.from).toEqual({ line: 0, ch: 5 })
+    expect(r.to).toEqual({ line: 0, ch: 10 })
+  })
+
+  it('handles multi-line selections forwards', () => {
+    const r = orderSelection({ line: 1, ch: 0 }, { line: 3, ch: 7 })
+    expect(r.from).toEqual({ line: 1, ch: 0 })
+    expect(r.to).toEqual({ line: 3, ch: 7 })
+  })
+
+  it('handles multi-line selections backwards', () => {
+    const r = orderSelection({ line: 3, ch: 7 }, { line: 1, ch: 0 })
+    expect(r.from).toEqual({ line: 1, ch: 0 })
+    expect(r.to).toEqual({ line: 3, ch: 7 })
+  })
+
+  it('treats equal positions as zero-width selection (anchor first)', () => {
+    const r = orderSelection({ line: 2, ch: 4 }, { line: 2, ch: 4 })
+    expect(r.from).toEqual({ line: 2, ch: 4 })
+    expect(r.to).toEqual({ line: 2, ch: 4 })
+  })
+})
+
+describe('applyLinkToProperty', () => {
+  const LINK = '[[Alpha]]'
+
+  it('sets the value when the property is missing', () => {
+    const fm: Record<string, unknown> = {}
+    applyLinkToProperty(fm, 'references', LINK)
+    expect(fm.references).toBe(LINK)
+  })
+
+  it('sets the value when the existing value is null', () => {
+    const fm: Record<string, unknown> = { references: null }
+    applyLinkToProperty(fm, 'references', LINK)
+    expect(fm.references).toBe(LINK)
+  })
+
+  it('sets the value when the existing value is an empty string', () => {
+    const fm: Record<string, unknown> = { references: '' }
+    applyLinkToProperty(fm, 'references', LINK)
+    expect(fm.references).toBe(LINK)
+  })
+
+  it('appends to an existing list (in-place mutation, no replacement)', () => {
+    const list: unknown[] = ['[[Beta]]']
+    const fm: Record<string, unknown> = { references: list }
+    applyLinkToProperty(fm, 'references', LINK)
+    expect(fm.references).toBe(list) // same array instance
+    expect(fm.references).toEqual(['[[Beta]]', LINK])
+  })
+
+  it('promotes a scalar string to a 2-element list to preserve the prior value', () => {
+    const fm: Record<string, unknown> = { references: '[[Beta]]' }
+    applyLinkToProperty(fm, 'references', LINK)
+    expect(fm.references).toEqual(['[[Beta]]', LINK])
+  })
+
+  it('promotes a scalar number to a list', () => {
+    const fm: Record<string, unknown> = { count: 42 }
+    applyLinkToProperty(fm, 'count', LINK)
+    expect(fm.count).toEqual([42, LINK])
+  })
+
+  it('does not touch unrelated properties', () => {
+    const fm: Record<string, unknown> = {
+      references: ['[[Beta]]'],
+      tags: ['fauna'],
+    }
+    applyLinkToProperty(fm, 'references', LINK)
+    expect(fm.tags).toEqual(['fauna'])
+  })
+})

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -15,6 +15,7 @@
   import {
     getCtrlKeyLabel,
     getAltKeyLabel,
+    getShiftKeyLabel,
     getExtension,
     isFilePDF,
     loopIndex,
@@ -22,7 +23,9 @@
   import {
     OmnisearchInFileModal,
     type OmnisearchVaultModal,
+    type CapturedSelection,
   } from '../components/modals'
+  import { OmnisearchFrontmatterLinkModal } from './frontmatter-link-modal'
   import ResultItemVault from './ResultItemVault.svelte'
   import { Query } from '../search/query'
   import { cancelable, CancelablePromise } from 'cancelable-promise'
@@ -34,10 +37,14 @@
     modal,
     previousQuery,
     plugin,
+    capturedSelection,
+    capturedFilePath,
   }: {
     modal: OmnisearchVaultModal
     previousQuery?: string | undefined
     plugin: OmnisearchPlugin
+    capturedSelection?: CapturedSelection | undefined
+    capturedFilePath?: string | undefined
   } = $props()
 
   let selectedIndex = $state(0)
@@ -107,6 +114,11 @@
     eventBus.on('vault', Action.CreateNote, createNoteAndCloseModal)
     eventBus.on('vault', Action.OpenInNewPane, openNoteInNewPane)
     eventBus.on('vault', Action.InsertLink, insertLink)
+    eventBus.on(
+      'vault',
+      Action.InsertLinkInFrontmatter,
+      insertLinkInFrontmatter
+    )
     eventBus.on('vault', Action.Tab, switchToInFileModal)
     eventBus.on('vault', Action.ArrowUp, () => moveIndex(-1))
     eventBus.on('vault', Action.ArrowDown, () => moveIndex(1))
@@ -245,30 +257,86 @@
       return
     }
 
-    // Generate link
+    // If the editor had a non-empty selection when Omnisearch was opened, use
+    // that selected text as the link alias and replace the range. Otherwise
+    // insert at the current cursor position (the pre-existing behaviour).
+    const hasSelection =
+      !!capturedSelection && capturedSelection.text.length > 0
+
     let link: string
     if (file && active) {
       link = plugin.app.fileManager.generateMarkdownLink(
         file,
         active.path,
         '',
-        selectedNote.displayTitle
+        hasSelection ? capturedSelection!.text : selectedNote.displayTitle
       )
     } else {
-      const maybeDisplayTitle =
-        selectedNote.displayTitle === '' ? '' : `|${selectedNote.displayTitle}`
+      const alias = hasSelection
+        ? capturedSelection!.text
+        : selectedNote.displayTitle
+      const maybeDisplayTitle = alias === '' ? '' : `|${alias}`
       link = `[[${selectedNote.basename}.${getExtension(
         selectedNote.path
       )}${maybeDisplayTitle}]]`
     }
 
-    // Inject link
-    const cursor = view.editor.getCursor()
-    view.editor.replaceRange(link, cursor, cursor)
-    cursor.ch += link.length
-    view.editor.setCursor(cursor)
+    if (hasSelection) {
+      view.editor.replaceRange(
+        link,
+        capturedSelection!.from,
+        capturedSelection!.to
+      )
+      // Place the cursor at the end of the inserted link on the last line it spans
+      const endLine = capturedSelection!.from.line
+      const endCh = capturedSelection!.from.ch + link.length
+      view.editor.setCursor({ line: endLine, ch: endCh })
+    } else {
+      const cursor = view.editor.getCursor()
+      view.editor.replaceRange(link, cursor, cursor)
+      cursor.ch += link.length
+      view.editor.setCursor(cursor)
+    }
 
     modal.close()
+  }
+
+  function insertLinkInFrontmatter(): void {
+    if (!selectedNote) return
+
+    // Resolve the file that was active when Omnisearch was opened. Falling back
+    // to the currently active file covers the case where the user explicitly
+    // focused a different pane behind the modal.
+    const path = capturedFilePath ?? plugin.app.workspace.getActiveFile()?.path
+    const active = path ? plugin.app.vault.getAbstractFileByPath(path) : null
+    if (!(active instanceof TFile)) {
+      new Notice(
+        'Omnisearch - No file to receive the link (open a note first)',
+        4000
+      )
+      return
+    }
+
+    const target = plugin.app.vault
+      .getMarkdownFiles()
+      .find(f => f.path === selectedNote.path)
+
+    // Always emit a wikilink here, regardless of the "Use [[Wikilinks]]"
+    // setting: Obsidian's property editor only renders wikilinks as link
+    // chips and only indexes those for graph/backlinks. A markdown-style link
+    // in YAML lands as a plain string. The user's setting still applies to
+    // body inserts (#425).
+    const linktext = target
+      ? plugin.app.metadataCache.fileToLinktext(target, active.path, true)
+      : `${selectedNote.basename}.${getExtension(selectedNote.path)}`
+    const alias =
+      selectedNote.displayTitle && selectedNote.displayTitle !== linktext
+        ? `|${selectedNote.displayTitle}`
+        : ''
+    const link = `[[${linktext}${alias}]]`
+
+    modal.close()
+    new OmnisearchFrontmatterLinkModal(plugin.app, plugin, active, link).open()
   }
 
   function switchToInFileModal(): void {
@@ -417,6 +485,14 @@
   <div class="prompt-instruction">
     <span class="prompt-instruction-command">{getAltKeyLabel()} ↵</span>
     <span>to insert a link</span>
+  </div>
+  <div class="prompt-instruction">
+    <span class="prompt-instruction-command">
+      {getCtrlKeyLabel()}
+      {getShiftKeyLabel()}
+      {getAltKeyLabel()} ↵
+    </span>
+    <span>to insert link into frontmatter</span>
   </div>
   <div class="prompt-instruction">
     <span class="prompt-instruction-command">{getCtrlKeyLabel()} g</span>

--- a/src/components/frontmatter-link-modal.ts
+++ b/src/components/frontmatter-link-modal.ts
@@ -1,0 +1,117 @@
+import { App, FuzzySuggestModal, Notice, TFile } from 'obsidian'
+import type OmnisearchPlugin from '../main'
+import { applyLinkToProperty } from '../tools/link-insertion'
+
+const NEW_PROPERTY_VALUE = '__omnisearch_new_property__'
+
+type PropertyChoice = {
+  name: string
+  existing: boolean
+  existingValue?: unknown
+}
+
+/**
+ * Asks the user which frontmatter property to insert a link into, then writes
+ * it using fileManager.processFrontMatter so Obsidian's link index picks it up.
+ */
+export class OmnisearchFrontmatterLinkModal extends FuzzySuggestModal<PropertyChoice> {
+  constructor(
+    app: App,
+    private plugin: OmnisearchPlugin,
+    private targetFile: TFile,
+    private linkMarkdown: string
+  ) {
+    super(app)
+    this.setPlaceholder(
+      'Pick a property to receive the link (or choose "New property...")'
+    )
+  }
+
+  getItems(): PropertyChoice[] {
+    const fm =
+      this.app.metadataCache.getFileCache(this.targetFile)?.frontmatter ?? {}
+    const existing: PropertyChoice[] = Object.keys(fm)
+      .filter(k => k !== 'position')
+      .map(name => ({ name, existing: true, existingValue: fm[name] }))
+    existing.sort((a, b) => a.name.localeCompare(b.name))
+    return [{ name: 'New property...', existing: false }, ...existing]
+  }
+
+  getItemText(item: PropertyChoice): string {
+    if (!item.existing) return '➕ New property...'
+    const preview = describeValue(item.existingValue)
+    return preview ? `${item.name}  —  ${preview}` : item.name
+  }
+
+  async onChooseItem(item: PropertyChoice): Promise<void> {
+    if (!item.existing) {
+      const picker = new NewPropertyNameModal(this.app, async name => {
+        if (!name) return
+        await this.writeProperty(name)
+      })
+      picker.open()
+      return
+    }
+    await this.writeProperty(item.name)
+  }
+
+  private async writeProperty(name: string): Promise<void> {
+    try {
+      await this.app.fileManager.processFrontMatter(this.targetFile, fm => {
+        applyLinkToProperty(fm, name, this.linkMarkdown)
+      })
+      new Notice(`Omnisearch: added link to "${name}"`, 3000)
+    } catch (err) {
+      console.error(err)
+      new Notice('Omnisearch: failed to write frontmatter', 4000)
+    }
+  }
+}
+
+function describeValue(v: unknown): string {
+  if (v == null) return ''
+  if (Array.isArray(v)) return `list (${v.length})`
+  if (typeof v === 'object') return 'object'
+  const s = String(v)
+  return s.length > 40 ? s.slice(0, 37) + '...' : s
+}
+
+/**
+ * Tiny prompt for a brand-new property name. Uses a plain HTML input inside a
+ * SuggestModal-style container so we don't pull in extra deps.
+ */
+import { Modal, Setting } from 'obsidian'
+
+class NewPropertyNameModal extends Modal {
+  private value = ''
+  constructor(app: App, private onSubmit: (name: string) => void) {
+    super(app)
+  }
+  onOpen(): void {
+    this.titleEl.setText('New frontmatter property')
+    new Setting(this.contentEl).setName('Property name').addText(t => {
+      t.setPlaceholder('e.g. references')
+      t.onChange(v => (this.value = v.trim()))
+      t.inputEl.addEventListener('keydown', e => {
+        if (e.key === 'Enter') {
+          e.preventDefault()
+          this.submit()
+        }
+      })
+      setTimeout(() => t.inputEl.focus(), 0)
+    })
+    new Setting(this.contentEl)
+      .addButton(b => b.setButtonText('Cancel').onClick(() => this.close()))
+      .addButton(b =>
+        b
+          .setCta()
+          .setButtonText('Insert')
+          .onClick(() => this.submit())
+      )
+  }
+  private submit(): void {
+    const name = this.value
+    this.close()
+    this.onSubmit(name)
+  }
+}

--- a/src/components/modals.ts
+++ b/src/components/modals.ts
@@ -1,10 +1,17 @@
 import { MarkdownView, Modal, TFile } from 'obsidian'
-import type { Modifier } from 'obsidian'
+import type { EditorPosition, Modifier } from 'obsidian'
 import ModalVault from './ModalVault.svelte'
 import ModalInFile from './ModalInFile.svelte'
 import { Action, eventBus, EventNames, isInputComposition } from '../globals'
 import type OmnisearchPlugin from '../main'
 import { mount, unmount } from 'svelte'
+import { orderSelection } from '../tools/link-insertion'
+
+export type CapturedSelection = {
+  from: EditorPosition
+  to: EditorPosition
+  text: string
+}
 
 abstract class OmnisearchModal extends Modal {
   protected constructor(plugin: OmnisearchPlugin) {
@@ -100,6 +107,12 @@ abstract class OmnisearchModal extends Modal {
       eventBus.emit(Action.InsertLink)
     })
 
+    // Insert link into frontmatter property
+    this.scope.register(['Mod', 'Shift', 'Alt'], 'Enter', e => {
+      e.preventDefault()
+      eventBus.emit(Action.InsertLinkInFrontmatter)
+    })
+
     // Create a new note
     this.scope.register(createInCurrentPaneKey, 'Enter', e => {
       e.preventDefault()
@@ -159,10 +172,25 @@ export class OmnisearchVaultModal extends OmnisearchModal {
   constructor(plugin: OmnisearchPlugin, query?: string) {
     super(plugin)
 
-    // Selected text in the editor
-    const selectedText = plugin.app.workspace
-      .getActiveViewOfType(MarkdownView)
-      ?.editor.getSelection()
+    // Capture editor state at modal open: the selection (range + text) and the
+    // active file. Opening the modal steals focus, so we snapshot this up-front
+    // and use it later for link insertion into the originating editor.
+    const mdView = plugin.app.workspace.getActiveViewOfType(MarkdownView)
+    const editor = mdView?.editor
+    let capturedSelection: CapturedSelection | undefined
+    let selectedText = ''
+    if (editor) {
+      const sel = editor.listSelections()[0]
+      if (sel) {
+        const { from, to } = orderSelection(sel.anchor, sel.head)
+        const text = editor.getRange(from, to)
+        if (text.length > 0) {
+          capturedSelection = { from, to, text }
+          selectedText = text
+        }
+      }
+    }
+    const capturedFilePath = mdView?.file?.path
 
     plugin.searchHistory.getHistory().then(history => {
       // Previously searched query (if enabled in settings)
@@ -177,6 +205,8 @@ export class OmnisearchVaultModal extends OmnisearchModal {
           plugin,
           modal: this,
           previousQuery: query || selectedText || previous || '',
+          capturedSelection,
+          capturedFilePath,
         },
       })
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -33,6 +33,7 @@ export const enum Action {
   CreateNote = 'create-note',
   OpenInNewPane = 'open-in-new-pane',
   InsertLink = 'insert-link',
+  InsertLinkInFrontmatter = 'insert-link-frontmatter',
   Tab = 'tab',
   ArrowUp = 'arrow-up',
   ArrowDown = 'arrow-down',

--- a/src/tools/link-insertion.ts
+++ b/src/tools/link-insertion.ts
@@ -1,0 +1,47 @@
+// Pure helpers for link insertion. No Obsidian runtime imports so these are
+// trivially testable in Jest without mocking the editor.
+
+export type Pos = { line: number; ch: number }
+
+export type SelectionRange = {
+  from: Pos
+  to: Pos
+}
+
+/**
+ * Returns the {from, to} pair such that `from` is always before `to` in
+ * document order. Selections in Obsidian can be made in either direction;
+ * `replaceRange` doesn't care, but `setCursor(from + linkLength)` does.
+ */
+export function orderSelection(anchor: Pos, head: Pos): SelectionRange {
+  const aFirst =
+    anchor.line < head.line ||
+    (anchor.line === head.line && anchor.ch <= head.ch)
+  return aFirst ? { from: anchor, to: head } : { from: head, to: anchor }
+}
+
+/**
+ * Frontmatter property write logic. Pure so we can test the array-promotion
+ * rule without having to spin up an Obsidian app.
+ *
+ * Rules:
+ *   - existing is a list  → append
+ *   - existing is missing/null/empty string → set to scalar `link`
+ *   - existing is any other scalar → promote to `[existing, link]`
+ */
+export function applyLinkToProperty(
+  fm: Record<string, unknown>,
+  name: string,
+  link: string
+): void {
+  const existing = fm[name]
+  if (Array.isArray(existing)) {
+    existing.push(link)
+    return
+  }
+  if (existing === undefined || existing === null || existing === '') {
+    fm[name] = link
+    return
+  }
+  fm[name] = [existing, link]
+}

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -153,9 +153,19 @@ export function getAltKeyLabel(): 'Alt' | '⌥' {
   return Platform.isMacOS ? '⌥' : 'Alt'
 }
 
+export function getShiftKeyLabel(): 'Shift' | '⇧' {
+  return Platform.isMacOS ? '⇧' : 'Shift'
+}
+
 export function isFileImage(path: string): boolean {
   const ext = getExtension(path)
-  return ext === 'png' || ext === 'jpg' || ext === 'jpeg' || ext === 'webp' || ext === 'gif'
+  return (
+    ext === 'png' ||
+    ext === 'jpg' ||
+    ext === 'jpeg' ||
+    ext === 'webp' ||
+    ext === 'gif'
+  )
 }
 
 export function isFilePDF(path: string): boolean {


### PR DESCRIPTION
Closes #425 and #443.

## Summary
Two additive link-insertion enhancements to `OmnisearchVaultModal`, both reachable from a normal vault search:

- **#425 — Wrap selected text with the link.** If the editor has a non-empty selection at the moment Omnisearch opens, `Alt+Enter` now replaces that selection with a link whose alias is the selected text. Behavior with no selection is unchanged. Respects the "Use [[Wikilinks]]" setting.
- **#443 — Insert link into a frontmatter property.** New shortcut `Ctrl+Shift+Alt+Enter` (`⌘⇧⌥↵` on macOS) closes the search modal and opens a `FuzzySuggestModal` listing the active note's existing frontmatter properties plus a "New property..." entry. Writes go through `app.fileManager.processFrontMatter`. Existing list values are appended; existing scalars are promoted to `[old, new]` so prior values aren't clobbered.

## Notable design call: wikilinks in frontmatter
The frontmatter shortcut always emits a wikilink regardless of the "Use [[Wikilinks]]" setting. The reason: Obsidian's property editor only renders wikilinks as link chips, and only the wikilink form is picked up by the metadata cache for graph and backlinks. A markdown-style link in YAML lands as a plain string and behaves like one — the user gets an inert value. The body-insert path from #425 continues to respect the user's setting; this exception is scoped to property inserts. Happy to revisit if you'd prefer the setting be respected everywhere.

## Implementation
- Pure helpers (`orderSelection`, `applyLinkToProperty`) extracted to `src/tools/link-insertion.ts` and unit-tested in `src/__tests__/link-insertion-tests.ts` (14 tests, 100% coverage on the new module).
- New `OmnisearchFrontmatterLinkModal` (`src/components/frontmatter-link-modal.ts`) — extends Obsidian's `FuzzySuggestModal` (the canonical fuzzy-picker for plugins). Happy to rewrite as a Svelte component if you'd prefer to keep all UI in Svelte per CONTRIBUTING.md.
- Selection range is captured in `modals.ts` before the modal steals focus, then passed to `ModalVault.svelte` as a prop.
- `getShiftKeyLabel()` added alongside the existing `getCtrlKeyLabel`/`getAltKeyLabel` helpers.
- `__mocks__/obsidian.ts` added so Jest can resolve the `obsidian` module; wired via `moduleNameMapper` in `jest.config.js`.
- No new runtime dependencies.
- Files formatted with the project's Prettier config.

## UX / settings
The new shortcut adds one row to the modal's footer hint list. If you'd prefer to gate either feature behind a settings toggle (e.g., to keep the footer compact, or in case `Ctrl+Shift+Alt+Enter` collides with something), I'm glad to add one — just say the word.

## Test plan
- [x] `npm test` — `link-insertion-tests` + `event-bus-tests` pass (the two pre-existing failing suites are upstream — Jest can't resolve `svelte/store` — and aren't touched here)
- [x] `npm run check` — svelte-check: 0 errors on the changed files
- [x] `npm run build` — tsc + esbuild green
- [x] Manual run in real Obsidian: highlight body text → Omnisearch → `Alt+Enter` → selection wrapped with the right alias under both wikilink and markdown-link settings
- [x] Manual run in real Obsidian: cursor anywhere → Omnisearch → `Ctrl+Shift+Alt+Enter` → property picker → choose existing list property or "New property..." → YAML updated, link chip rendered