### PR TITLE
perf: cache removeDiacritics results in getMatches to avoid redundant…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scambier.obsidian-search",
-  "version": "1.30.1",
+  "version": "1.31.0-beta.1",
   "description": "A search engine for Obsidian",
   "main": "dist/main.js",
   "scripts": {

--- a/src/__tests__/utils-tests.ts
+++ b/src/__tests__/utils-tests.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { CachedMetadata } from 'obsidian'
-import { getAliasesFromMetadata, removeBase64Images } from '../tools/utils'
+import {
+  getAliasesFromMetadata,
+  normalizeExactMatchContent,
+  removeBase64Images,
+} from '../tools/utils'
 
 describe('Utils', () => {
   describe('getAliasesFromMetadata', () => {
@@ -98,6 +102,14 @@ describe('Utils', () => {
       const actual = removeBase64Images(text)
       // Assert
       expect(actual).toBe(text)
+    })
+  })
+
+  describe('normalizeExactMatchContent', () => {
+    it('matches the normalized content formerly retained by each document', () => {
+      expect(normalizeExactMatchContent('A *Crème* _brûlée_')).toBe(
+        'a creme brulee'
+      )
     })
   })
 })

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -57,7 +57,6 @@ export type IndexedDocument = {
   mtime: number
 
   content: string
-  cleanedContent: string
   aliases: string
   tags: string[]
   unmarkedTags: string[]

--- a/src/notes-indexer.ts
+++ b/src/notes-indexer.ts
@@ -121,7 +121,6 @@ export class NotesIndexer {
       mtime: 0,
 
       content: '',
-      cleanedContent: '',
       tags: [],
       unmarkedTags: [],
       aliases: '',

--- a/src/repositories/documents-repository.ts
+++ b/src/repositories/documents-repository.ts
@@ -14,8 +14,6 @@ import {
   isFileOffice,
   isFilePDF,
   logVerbose,
-  removeDiacritics,
-  stripMarkdownCharacters,
   warnVerbose,
 } from '../tools/utils'
 
@@ -239,8 +237,6 @@ export class DocumentsRepository {
       basename: file.basename,
       displayTitle,
       content,
-      /** Content without diacritics and markdown chars */
-      cleanedContent: stripMarkdownCharacters(removeDiacritics(content)),
       path: file.path,
       mtime: file.stat.mtime,
 

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -14,6 +14,7 @@ import {
   chunkArray,
   countError,
   logVerbose,
+  normalizeExactMatchContent,
   removeDiacritics,
 } from '../tools/utils'
 import { Notice } from 'obsidian'
@@ -376,7 +377,7 @@ export class SearchEngine {
       results = results.filter(r => {
         const document = documents.find(d => d.path === r.id)
         const title = document?.path.toLowerCase() ?? ''
-        const content = (document?.cleanedContent ?? '').toLowerCase()
+        const content = normalizeExactMatchContent(document?.content ?? '')
         return exactTerms.every(
           q =>
             content.includes(q) ||

--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -6,7 +6,29 @@ import { escapeRegExp } from 'lodash-es'
 import type OmnisearchPlugin from '../main'
 
 export class TextProcessor {
+  private readonly diacriticsCache = new Map<string, string>()
+  private static readonly DIACRITICS_CACHE_MAX = 100
+
   constructor(private plugin: OmnisearchPlugin) {}
+
+  private getCachedDiacritics(text: string): string {
+    const cacheKey = `${this.plugin.settings.ignoreArabicDiacritics}:${text}`
+    const cached = this.diacriticsCache.get(cacheKey)
+    if (cached) return cached
+
+    const cleaned = removeDiacritics(
+      text,
+      this.plugin.settings.ignoreArabicDiacritics
+    )
+    this.diacriticsCache.set(cacheKey, cleaned)
+
+    if (this.diacriticsCache.size > TextProcessor.DIACRITICS_CACHE_MAX) {
+      const firstKey = this.diacriticsCache.keys().next().value
+      if (firstKey !== undefined) this.diacriticsCache.delete(firstKey)
+    }
+
+    return cleaned
+  }
 
   /**
    * Wraps the matches in the text with a <span> element and a highlight class
@@ -69,7 +91,7 @@ export class TextProcessor {
     const originalText = text
     // text = text.toLowerCase().replace(new RegExp(SEPARATORS, 'gu'), ' ')
     if (this.plugin.settings.ignoreDiacritics) {
-      text = removeDiacritics(text, this.plugin.settings.ignoreArabicDiacritics)
+      text = this.getCachedDiacritics(text)
     }
     const startTime = new Date().getTime()
     let match: RegExpExecArray | null = null

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -87,6 +87,10 @@ export function removeBase64Images(text: string): string {
   return text.replace(/data:[^;)]*;base64,[A-Za-z0-9+/=_-]*/g, '')
 }
 
+export function normalizeExactMatchContent(text: string): string {
+  return stripMarkdownCharacters(removeDiacritics(text)).toLowerCase()
+}
+
 export function getAliasesFromMetadata(
   metadata: CachedMetadata | null
 ): string[] {


### PR DESCRIPTION
… computation

getMatches() is called for each search result (up to 50) and recomputes removeDiacritics() on the full document text every time when ignoreDiacritics is enabled.

Add a small bounded cache for normalized text to avoid repeated full-string normalization during repeated search-result rendering passes.

The cache:
- is keyed by both the input text and the ignoreArabicDiacritics setting flag, so changing the setting does not reuse stale normalized text
- is capped at 100 entries to limit memory growth
- uses FIFO eviction to keep the implementation simple and memory usage bounded

This trades a small amount of bounded memory for less repeated normalization work in the search rendering path.