### PR TITLE
fix: don't clear cache when toggling aiImageIndexing

### DIFF
--- a/src/settings/settings-indexing.ts
+++ b/src/settings/settings-indexing.ts
@@ -98,7 +98,6 @@ export function injectSettingsIndexing(
     .setDesc(aiIndexImagesDesc)
     .addToggle(toggle =>
       toggle.setValue(settings.aiImageIndexing).onChange(async v => {
-        await database.clearCache()
         settings.aiImageIndexing = v
         await saveSettings(plugin)
       })


### PR DESCRIPTION
## Summary
- Remove `database.clearCache()` call from `aiImageIndexing` toggle handler
- Preserve existing OmniSearch index when enabling/disabling AI image indexing

## Problem
Toggling the "Images AI indexing" setting clears the entire OmniSearch cache (IndexedDB), which forces a complete re-index of all vault files. For vaults with thousands of images, this triggers expensive AI image analysis (via AI Image Analyzer) for every single image, which can take hours and makes Obsidian unresponsive.

This makes the setting effectively a one-way switch — once enabled, users cannot safely toggle it without losing all cached index data.

## Solution
Remove the `clearCache()` call from the `aiImageIndexing` onChange handler. The index will naturally incorporate or exclude AI image data on the next incremental index update without requiring a full rebuild.

## Changes
- **Modified**: `src/settings/settings-indexing.ts` — Removed `await database.clearCache()` from aiImageIndexing toggle (1 line)

## Test plan
- [x] Build succeeds
- [ ] Toggle aiImageIndexing off → on: index is preserved, no "No cache found" on restart
- [ ] New images added after toggle are indexed correctly
- [ ] Toggling off excludes AI image data from future searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)