### PR TITLE
fix: ignore deleted files queued for reindex

### DIFF
--- a/src/__tests__/notes-indexer-tests.ts
+++ b/src/__tests__/notes-indexer-tests.ts
@@ -1,0 +1,52 @@
+jest.mock(
+  'obsidian',
+  () => ({
+    getAllTags: jest.fn(() => []),
+    MarkdownView: class MarkdownView {},
+    Notice: jest.fn(),
+    parseFrontMatterAliases: jest.fn(() => []),
+    Platform: {},
+    TFile: class TFile {},
+    WorkspaceLeaf: class WorkspaceLeaf {},
+  }),
+  { virtual: true }
+)
+jest.mock(
+  'svelte/store',
+  () => ({
+    writable: jest.fn(() => ({
+      set: jest.fn(),
+      subscribe: jest.fn(),
+      update: jest.fn(),
+    })),
+  }),
+  { virtual: true }
+)
+
+import { NotesIndexer } from '../notes-indexer'
+
+describe('NotesIndexer', () => {
+  test('removes deleted notes from the reindex queue by path', async () => {
+    const addDocument = jest.fn()
+    const removeFromPaths = jest.fn()
+    const addFromPaths = jest.fn()
+    const plugin = {
+      documentsRepository: { addDocument },
+      searchEngine: { removeFromPaths, addFromPaths },
+      settings: {},
+      app: { metadataCache: {} },
+      getTextExtractor: () => null,
+      getAIImageAnalyzer: () => null,
+    }
+    const notesIndexer = new NotesIndexer(plugin as unknown as ConstructorParameters<typeof NotesIndexer>[0])
+
+    notesIndexer.flagNoteForReindex({ path: 'deleted.md' } as Parameters<NotesIndexer['flagNoteForReindex']>[0])
+    notesIndexer.unflagNoteForReindex('deleted.md')
+
+    await notesIndexer.refreshIndex()
+
+    expect(addDocument).not.toHaveBeenCalled()
+    expect(removeFromPaths).not.toHaveBeenCalled()
+    expect(addFromPaths).not.toHaveBeenCalled()
+  })
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,6 +131,7 @@ export default class OmnisearchPlugin extends Plugin {
           this.documentsRepository.removeDocument(file.path)
           searchEngine.removeFromPaths([file.path])
           this.embedsRepository.removeFile(file.path)
+          this.notesIndexer.unflagNoteForReindex(file.path)
         })
       )
       this.registerEvent(

--- a/src/notes-indexer.ts
+++ b/src/notes-indexer.ts
@@ -24,6 +24,14 @@ export class NotesIndexer {
     this.notesToReindex.add(note)
   }
 
+  public unflagNoteForReindex(path: string): void {
+    for (const note of this.notesToReindex) {
+      if (note.path === path) {
+        this.notesToReindex.delete(note)
+      }
+    }
+  }
+
   public async refreshIndex(): Promise<void> {
     for (const file of this.notesToReindex) {
       logVerbose('Updating file', file.path)

--- a/src/repositories/documents-repository.ts
+++ b/src/repositories/documents-repository.ts
@@ -43,6 +43,7 @@ export class DocumentsRepository {
   public async addDocument(path: string): Promise<void> {
     try {
       const doc = await this.getAndMapIndexedDocument(path)
+      if (!doc) return
       if (!doc.path) {
         console.error(
           `Missing .path field in IndexedDocument "${doc.basename}", skipping`
@@ -88,11 +89,11 @@ export class DocumentsRepository {
    */
   private async getAndMapIndexedDocument(
     path: string
-  ): Promise<IndexedDocument> {
+  ): Promise<IndexedDocument | null> {
     path = normalizePath(path)
     const app = this.plugin.app
     const file = app.vault.getAbstractFileByPath(path)
-    if (!file) throw new Error(`Invalid file path: "${path}"`)
+    if (!file) return null
     if (!(file instanceof TFile)) throw new Error(`Not a TFile: "${path}"`)
     let content: string | null = null
 


### PR DESCRIPTION
## Summary
- remove deleted files from the pending reindex queue when Obsidian emits a delete event
- make live-cache document adds skip paths that disappear before indexing
- add a regression test for the deleted-file reindex queue cleanup

Fixes #536

## Verification
- `corepack pnpm test -- --runTestsByPath src/__tests__/notes-indexer-tests.ts`
- `npx eslint src/__tests__/notes-indexer-tests.ts src/notes-indexer.ts`
- `corepack pnpm build`
- `git diff --check`

Note: `corepack pnpm lint` still reports existing lint issues outside this change; the touched files above pass targeted lint.
