### PR TITLE
docs(readme): add obsidian-mcp-server to Projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ _Submit a PR to add your own project!_
 - [Actions for Obsidian](https://actions.work/actions-for-obsidian)
 - [Notebook Navigator](https://notebooknavigator.com/)
 - [Userscripts](https://publish.obsidian.md/omnisearch/Inject+Omnisearch+results+into+your+search+engine) to inject Omnisearch into your favorite web search engine
-- [Obsidian MCP Server](https://github.com/cyanheads/obsidian-mcp-server), an MCP server that auto-detects Omnisearch and exposes it as a BM25-ranked search mode for AI agents accessing your vault
+- [obsidian-mcp-server](https://github.com/cyanheads/obsidian-mcp-server), an MCP server that auto-detects Omnisearch and exposes it as a BM25-ranked search mode for AI agents accessing your vault
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ _Submit a PR to add your own project!_
 - [Actions for Obsidian](https://actions.work/actions-for-obsidian)
 - [Notebook Navigator](https://notebooknavigator.com/)
 - [Userscripts](https://publish.obsidian.md/omnisearch/Inject+Omnisearch+results+into+your+search+engine) to inject Omnisearch into your favorite web search engine
+- [Obsidian MCP Server](https://github.com/cyanheads/obsidian-mcp-server), an MCP server that auto-detects Omnisearch and exposes it as a BM25-ranked search mode for AI agents accessing your vault
 
 ## LICENSE
 


### PR DESCRIPTION
Adds [obsidian-mcp-server](https://github.com/cyanheads/obsidian-mcp-server) — an MCP server that exposes Obsidian to AI agents — to the projects list.

It auto-detects Omnisearch's HTTP server at startup (probes `GET /search?q=` for status + `application/json` + JSON-array body) and registers it as a BM25-ranked search mode on the server's `obsidian_search_notes` tool, so LLM tool calls get ranked relevance, typo tolerance, and PDF/OCR coverage via Text Extractor. Released in [v3.2.0](https://github.com/cyanheads/obsidian-mcp-server/releases/tag/v3.2.0).

Thanks for building Omnisearch. Let me know if you have any questions/concerns.
