### PR TITLE
fix(mobile): pass 'tab' explicitly for new tabs to fix issue on android (#410)

### DIFF
--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -51,7 +51,7 @@ export async function openNote(
       await app.workspace.openLinkText(
         linkPath,
         '',
-        newLeaf ? 'split' : newPane
+        newLeaf ? 'split' : (newPane === true ? 'tab' : newPane)
       )
       return
     }
@@ -95,13 +95,13 @@ export async function openNote(
         : undefined
 
     if (existingFile instanceof TFile) {
-      const leaf = app.workspace.getLeaf(newLeaf ? 'split' : newPane)
+      const leaf = app.workspace.getLeaf(newLeaf ? 'split' : (newPane === true ? 'tab' : newPane))
       await leaf.openFile(existingFile, { active: !newLeaf && !newPane })
     } else {
       await app.workspace.openLinkText(
         item.path,
         '',
-        newLeaf ? 'split' : newPane
+        newLeaf ? 'split' : (newPane === true ? 'tab' : newPane)
       )
     }
   }

--- a/src/tools/notes.ts
+++ b/src/tools/notes.ts
@@ -51,7 +51,7 @@ export async function openNote(
       await app.workspace.openLinkText(
         linkPath,
         '',
-        newLeaf ? 'split' : (newPane === true ? 'tab' : newPane)
+        newLeaf ? 'split' : (newPane ? 'tab' : newPane)
       )
       return
     }
@@ -95,13 +95,13 @@ export async function openNote(
         : undefined
 
     if (existingFile instanceof TFile) {
-      const leaf = app.workspace.getLeaf(newLeaf ? 'split' : (newPane === true ? 'tab' : newPane))
+      const leaf = app.workspace.getLeaf(newLeaf ? 'split' : (newPane ? 'tab' : newPane))
       await leaf.openFile(existingFile, { active: !newLeaf && !newPane })
     } else {
       await app.workspace.openLinkText(
         item.path,
         '',
-        newLeaf ? 'split' : (newPane === true ? 'tab' : newPane)
+        newLeaf ? 'split' : (newPane ? 'tab' : newPane)
       )
     }
   }


### PR DESCRIPTION
Fixes #410. Obsidian Mobile behavior replaces the active leaf if \
ewLeaf\ is passed as \	rue\ to \openLinkText\ or \getLeaf\. Passing \'tab'\ explicitly ensures that a new tab is spawned. Desktop behavior remains fully intact since \'tab'\ has been supported explicitly since v1.0+ for exactly this workflow.