### PR TITLE
Add built-in Han substring recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ This changelog is not exhaustive.
 
 ## 1.29.x
 
-* Add built-in Han substring recall and automatic search-index cache migration ([#558](https://github.com/scambier/obsidian-omnisearch/issues/558))
 * Feature/537 add index files without extension by @Acallaris738 in https://github.com/scambier/obsidian-omnisearch/pull/538
 * Fix: Skip excluded files during indexing when hideExcluded is enabled by @byte74128 in https://github.com/scambier/obsidian-omnisearch/pull/530
 * feat: Highlight search result on open with cursor at match start by @Evgene-Kopylov in https://github.com/scambier/obsidian-omnisearch/pull/539

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog is not exhaustive.
 
 ## 1.29.x
 
+* Add built-in Han substring recall and automatic search-index cache migration ([#558](https://github.com/scambier/obsidian-omnisearch/issues/558))
 * Feature/537 add index files without extension by @Acallaris738 in https://github.com/scambier/obsidian-omnisearch/pull/538
 * Fix: Skip excluded files during indexing when hideExcluded is enabled by @byte74128 in https://github.com/scambier/obsidian-omnisearch/pull/530
 * feat: Highlight search result on open with cursor at match start by @Evgene-Kopylov in https://github.com/scambier/obsidian-omnisearch/pull/539

--- a/README.md
+++ b/README.md
@@ -51,9 +51,12 @@ You can check the [CHANGELOG](./CHANGELOG.md) for more information on the differ
 - Directly Insert a `[[link]]` from the search results
 - Supports Vim navigation keys
 
-**Note:** support of Chinese depends
-on [this additional plugin](https://github.com/aidenlx/cm-chs-patch) (also you may need to clear search cache data to apply new Chinese index). Please read its documentation for more
-information.
+**Chinese search:** Omnisearch includes a dependency-free fallback for internal
+Han substrings of two or more characters. The
+[Chinese Support Patch](https://github.com/aidenlx/cm-chs-patch) remains
+optional and can improve word-aware tokenization and ranking. Omnisearch
+automatically rebuilds an incompatible search index after its tokenization
+schema or the optional tokenizer changes.
 
 ## Projects that use Omnisearch
 

--- a/src/__tests__/han-grams-tests.ts
+++ b/src/__tests__/han-grams-tests.ts
@@ -1,0 +1,123 @@
+import {
+  HAN_GRAM_PREFIX,
+  createIndexSignature,
+  createHanQueryPlan,
+  documentContainsHanRuns,
+  extractHanRuns,
+  isHanIndexCharacter,
+  markHanGram,
+  reconcileVerifiedHanResults,
+  requiresHanVerification,
+  tokenizeHanBigrams,
+} from '../search/han-grams'
+
+describe('Han gram fallback helpers', () => {
+  it('recognizes Han letters without accepting punctuation or other scripts', () => {
+    expect(isHanIndexCharacter('中')).toBe(true)
+    expect(isHanIndexCharacter('𠀀')).toBe(true)
+    expect(isHanIndexCharacter('々')).toBe(true)
+    expect(isHanIndexCharacter('〇')).toBe(true)
+    expect(isHanIndexCharacter('。')).toBe(false)
+    expect(isHanIndexCharacter('あ')).toBe(false)
+    expect(isHanIndexCharacter('한')).toBe(false)
+  })
+
+  it('extracts Han runs across mixed text and punctuation', () => {
+    expect(extractHanRuns('机器学习with TypeScript中文。搜索')).toEqual([
+      '机器学习',
+      '中文',
+      '搜索',
+    ])
+  })
+
+  it('creates overlapping bigrams by Unicode code point', () => {
+    expect(tokenizeHanBigrams('周五的时候')).toEqual([
+      '周五',
+      '五的',
+      '的时',
+      '时候',
+    ])
+    expect(tokenizeHanBigrams('𠀀野家')).toEqual(['𠀀野', '野家'])
+    expect(tokenizeHanBigrams('二〇二六')).toEqual(['二〇', '〇二', '二六'])
+  })
+
+  it('does not cross punctuation and preserves real repeated occurrences', () => {
+    expect(tokenizeHanBigrams('中文。搜索')).toEqual(['中文', '搜索'])
+    expect(tokenizeHanBigrams('哈哈哈')).toEqual(['哈哈', '哈哈'])
+    expect(tokenizeHanBigrams('中')).toEqual([])
+  })
+
+  it('builds a deduplicated query plan while preserving separated constraints', () => {
+    const mixedPlan = createHanQueryPlan('projectA 时候 时候')
+    expect(mixedPlan?.runs).toEqual(['时候', '时候'])
+    expect(mixedPlan?.grams).toEqual([markHanGram('时候')])
+    expect(mixedPlan?.remainingText.trim()).toBe('projectA')
+
+    const singleCharacterPlan = createHanQueryPlan('中 时候')
+    expect(singleCharacterPlan?.runs).toEqual(['时候'])
+    expect(singleCharacterPlan?.grams).toEqual([markHanGram('时候')])
+    expect(singleCharacterPlan?.remainingText.trim()).toBe('中')
+
+    const fullwidthPlan = createHanQueryPlan('Ｐroject 时候')
+    expect(fullwidthPlan?.remainingText.trim()).toBe('Ｐroject')
+  })
+
+  it('keeps attached mixed-script tokens on the legacy path in v1', () => {
+    expect(createHanQueryPlan('时候bar')).toBeNull()
+    expect(createHanQueryPlan('foo时候')).toBeNull()
+
+    const partialPlan = createHanQueryPlan('时候 foo中文bar')
+    expect(partialPlan?.runs).toEqual(['时候'])
+    expect(partialPlan?.remainingText.trim()).toBe('foo中文bar')
+  })
+
+  it('verifies every run within an individual original field', () => {
+    expect(documentContainsHanRuns(['甲乙丙'], ['前甲乙丙后', '其他'])).toBe(
+      true
+    )
+    expect(documentContainsHanRuns(['甲乙丙'], ['甲乙', '乙丙'])).toBe(false)
+    expect(
+      documentContainsHanRuns(['甲乙', '丁戊'], ['前甲乙后', '前丁戊后'])
+    ).toBe(true)
+  })
+
+  it('requires raw verification only for runs longer than one bigram', () => {
+    expect(requiresHanVerification(['时候'])).toBe(false)
+    expect(requiresHanVerification(['甲乙丙'])).toBe(true)
+  })
+
+  it('changes the cache signature when index-affecting inputs change', () => {
+    const base = {
+      tokenizeUrls: true,
+      ignoreDiacritics: true,
+      ignoreArabicDiacritics: false,
+      chsPatch: 'absent' as const,
+    }
+    const signature = createIndexSignature(base)
+    expect(signature).toBe(createIndexSignature(base))
+    expect(JSON.parse(signature)).toEqual(
+      expect.objectContaining({ gramMarker: HAN_GRAM_PREFIX })
+    )
+    expect(createIndexSignature(base)).not.toBe(
+      createIndexSignature({ ...base, chsPatch: '1.2.3' })
+    )
+    expect(createIndexSignature(base)).not.toBe(
+      createIndexSignature({ ...base, tokenizeUrls: false })
+    )
+  })
+
+  it('uses natural scores when an unverified fallback also matched', () => {
+    const natural = [{ id: 'natural', score: 2 }]
+    const combined = [
+      { id: 'false-fallback', score: 10 },
+      { id: 'natural', score: 8 },
+      { id: 'verified', score: 3 },
+    ]
+    expect(
+      reconcileVerifiedHanResults(natural, combined, new Set(['verified']))
+    ).toEqual([
+      { id: 'verified', score: 3 },
+      { id: 'natural', score: 2 },
+    ])
+  })
+})

--- a/src/__tests__/han-search-engine-tests.ts
+++ b/src/__tests__/han-search-engine-tests.ts
@@ -1,0 +1,386 @@
+jest.mock(
+  'obsidian',
+  () => ({
+    Notice: class Notice {},
+    Platform: { isMobile: false },
+    getAllTags: () => [],
+    parseFrontMatterAliases: () => [],
+  }),
+  { virtual: true }
+)
+
+jest.mock('svelte/store', () => ({
+  writable: (value: unknown) => ({
+    subscribe: () => () => undefined,
+    set: () => undefined,
+    update: (updater: (current: unknown) => unknown) => updater(value),
+  }),
+}))
+
+jest.mock('markdown-link-extractor', () => () => [])
+
+import type { IndexedDocument } from '../globals'
+import type OmnisearchPlugin from '../main'
+import { Query } from '../search/query'
+import { SearchEngine } from '../search/search-engine'
+
+const makeDocument = (
+  path: string,
+  content: string,
+  overrides: Partial<IndexedDocument> = {}
+): IndexedDocument => ({
+  path,
+  basename: path.replace(/\.md$/, ''),
+  displayTitle: '',
+  mtime: 1,
+  content,
+  cleanedContent: content,
+  aliases: '',
+  tags: [],
+  unmarkedTags: [],
+  headings1: '',
+  headings2: '',
+  headings3: '',
+  ...overrides,
+})
+
+const query = (text: string) =>
+  new Query(text, {
+    ignoreDiacritics: false,
+    ignoreArabicDiacritics: false,
+  })
+
+const makePlugin = (
+  documents: IndexedDocument[],
+  cache: unknown = null,
+  chsSegmenter?: unknown
+) => {
+  const byPath = new Map(documents.map(document => [document.path, document]))
+  return {
+    settings: {
+      tokenizeUrls: false,
+      ignoreDiacritics: false,
+      ignoreArabicDiacritics: false,
+      fuzziness: '0',
+      recencyBoost: '0',
+      weightBasename: 2,
+      weightDirectory: 1,
+      weightH1: 1,
+      weightH2: 1,
+      weightH3: 1,
+      weightUnmarkedTags: 1,
+      weightCustomProperties: [],
+      downrankedFoldersFilters: [],
+      hideExcluded: false,
+      simpleSearch: false,
+      maxEmbeds: 0,
+    },
+    getChsSegmenter: () => chsSegmenter,
+    documentsRepository: {
+      getDocument: jest.fn(async (path: string) => byPath.get(path)),
+    },
+    embedsRepository: {
+      loadFromCache: jest.fn(async () => undefined),
+      getEmbeds: (_path: string): string[] => [],
+    },
+    database: {
+      getMinisearchCache: jest.fn(async () => cache),
+    },
+    app: {
+      metadataCache: {
+        isUserIgnored: () => false,
+        getCache: () => null,
+      },
+    },
+    textProcessor: {
+      getMatches: jest.fn(() => []),
+    },
+  }
+}
+
+const createEngine = async (documents: IndexedDocument[]) => {
+  const plugin = makePlugin(documents)
+  const engine = new SearchEngine(plugin as unknown as OmnisearchPlugin)
+  await engine.addFromPaths(documents.map(document => document.path))
+  return { engine, plugin }
+}
+
+const search = (engine: SearchEngine, text: string) =>
+  engine.search(query(text), { prefixLength: 1 })
+
+describe('SearchEngine Han substring fallback', () => {
+  it('recalls the reported internal bigram without enabling single-char infix', async () => {
+    const { engine } = await createEngine([
+      makeDocument('example.md', '周五的时候'),
+    ])
+
+    await expect(search(engine, '周五')).resolves.toHaveLength(1)
+    await expect(search(engine, '时候')).resolves.toEqual([
+      expect.objectContaining({ tags: [], mtime: 1 }),
+    ])
+    await expect(search(engine, '时')).resolves.toHaveLength(0)
+  })
+
+  it('verifies long runs and rejects separated or cross-field grams', async () => {
+    const { engine } = await createEngine([
+      makeDocument('true.md', '前甲乙丙后'),
+      makeDocument('separated.md', '甲乙在前，乙丙在后'),
+      makeDocument('cross-field.md', '乙丙', { basename: '甲乙' }),
+    ])
+
+    await expect(search(engine, '甲乙丙')).resolves.toEqual([
+      expect.objectContaining({ id: 'true.md' }),
+    ])
+  })
+
+  it('verifies before top-50 so false gram candidates cannot hide a true hit', async () => {
+    const falseCandidates = Array.from({ length: 60 }, (_, index) =>
+      makeDocument(
+        `false-${index}.md`,
+        '甲乙 甲乙 甲乙在前，乙丙 乙丙 乙丙在后'
+      )
+    )
+    const { engine } = await createEngine([
+      ...falseCandidates,
+      makeDocument('true.md', '甲乙丙'),
+    ])
+
+    await expect(search(engine, '甲乙丙')).resolves.toEqual([
+      expect.objectContaining({ id: 'true.md' }),
+    ])
+  })
+
+  it('stops cold candidate hydration after the active batch is aborted', async () => {
+    const documents = [
+      ...Array.from({ length: 120 }, (_, index) =>
+        makeDocument(`false-${index}.md`, '甲乙在前，乙丙在后')
+      ),
+      makeDocument('true.md', '甲乙丙'),
+    ]
+    const { engine, plugin } = await createEngine(documents)
+    const controller = new AbortController()
+    let hydrationCount = 0
+    plugin.documentsRepository.getDocument.mockImplementation(
+      async (path: string) => {
+        hydrationCount++
+        if (hydrationCount === 1) controller.abort()
+        return documents.find(document => document.path === path)
+      }
+    )
+
+    await expect(
+      engine.search(query('甲乙丙'), {
+        prefixLength: 1,
+        signal: controller.signal,
+      })
+    ).resolves.toEqual([])
+    expect(hydrationCount).toBeLessThanOrEqual(50)
+  })
+
+  it('stops embed hydration after the active suggestion request is aborted', async () => {
+    const documents = [
+      makeDocument('main.md', '周五的时候'),
+      makeDocument('embed-1.md', ''),
+      makeDocument('embed-2.md', ''),
+    ]
+    const { engine, plugin } = await createEngine(documents)
+    const controller = new AbortController()
+    plugin.settings.maxEmbeds = 2
+    plugin.embedsRepository.getEmbeds = jest.fn((path: string) =>
+      path === 'main.md' ? ['embed-1.md', 'embed-2.md'] : []
+    )
+    plugin.documentsRepository.getDocument.mockImplementation(
+      async (path: string) => {
+        if (path === 'embed-1.md') controller.abort()
+        return documents.find(document => document.path === path)
+      }
+    )
+    plugin.documentsRepository.getDocument.mockClear()
+
+    await expect(
+      engine.getSuggestions(query('时候'), { signal: controller.signal })
+    ).resolves.toEqual([])
+    expect(plugin.documentsRepository.getDocument).not.toHaveBeenCalledWith(
+      'embed-2.md'
+    )
+  })
+
+  it('keeps separated Latin constraints in the fallback branch', async () => {
+    const { engine } = await createEngine([
+      makeDocument('a.md', 'projectA 周五的时候'),
+      makeDocument('b.md', 'projectB 周五的时候'),
+    ])
+
+    await expect(search(engine, 'projectA 时候')).resolves.toEqual([
+      expect.objectContaining({ id: 'a.md' }),
+    ])
+  })
+
+  it('preserves path, extension, quote, and exclusion filters', async () => {
+    const { engine } = await createEngine([
+      makeDocument('folder/keep.md', '前甲乙丙后 周五的时候'),
+      makeDocument('folder/excluded.md', '前甲乙丙后 周五的时候 排除'),
+      makeDocument('other/keep.md', '前甲乙丙后 周五的时候'),
+      makeDocument('folder/keep.txt', '前甲乙丙后 周五的时候'),
+      makeDocument('folder/quote.md', 'foo xxx bar'),
+    ])
+
+    await expect(
+      search(engine, '"甲乙丙" path:folder ext:md -排除')
+    ).resolves.toEqual([expect.objectContaining({ id: 'folder/keep.md' })])
+    await expect(
+      engine.search(query('甲乙丙 -排除'), {
+        prefixLength: 1,
+        singleFilePath: 'folder/excluded.md',
+      })
+    ).resolves.toEqual([])
+    await expect(
+      engine.search(query('"foo bar"'), {
+        prefixLength: 1,
+        singleFilePath: 'folder/quote.md',
+      })
+    ).resolves.toEqual([])
+  })
+
+  it('does not broaden attached mixed-script or non-Han script queries', async () => {
+    const { engine } = await createEngine([
+      makeDocument('mixed.md', '前时候bar后 foo周五的时候'),
+      makeDocument('japanese.md', '食べる'),
+      makeDocument('korean.md', '한국어검색'),
+      makeDocument('latin.md', 'projectAlpha'),
+    ])
+
+    await expect(search(engine, '时候bar')).resolves.toHaveLength(0)
+    await expect(search(engine, 'foo时候')).resolves.toHaveLength(0)
+    await expect(search(engine, 'べる')).resolves.toHaveLength(0)
+    await expect(search(engine, '검색')).resolves.toHaveLength(0)
+    const latinQuery = query('project')
+    const rawTextSpy = jest.spyOn(latinQuery, 'rawSegmentsToStr')
+    await expect(
+      engine.search(latinQuery, { prefixLength: 1 })
+    ).resolves.toEqual([expect.objectContaining({ id: 'latin.md' })])
+    expect(rawTextSpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps compatibility ideographs raw so retrieval and highlighting agree', async () => {
+    const { engine } = await createEngine([
+      makeDocument('compatibility.md', '神社'),
+    ])
+
+    await expect(search(engine, '神社')).resolves.toHaveLength(0)
+    await expect(search(engine, '神社')).resolves.toHaveLength(1)
+  })
+
+  it('keeps raw Han fallback semantics when diacritic folding is enabled', async () => {
+    const documents = [makeDocument('compatibility.md', '前神社後面')]
+    const plugin = makePlugin(documents)
+    plugin.settings.ignoreDiacritics = true
+    const engine = new SearchEngine(plugin as unknown as OmnisearchPlugin)
+    await engine.addFromPaths(['compatibility.md'])
+    const normalizedQuery = (text: string) =>
+      new Query(text, {
+        ignoreDiacritics: true,
+        ignoreArabicDiacritics: false,
+      })
+    const run = (text: string) =>
+      engine.search(normalizedQuery(text), { prefixLength: 1 })
+
+    await expect(run('神社')).resolves.toHaveLength(1)
+    await expect(run('神社')).resolves.toHaveLength(0)
+    await expect(run('神社後')).resolves.toHaveLength(1)
+    await engine.getSuggestions(normalizedQuery('神社後'))
+    expect(plugin.textProcessor.getMatches).toHaveBeenLastCalledWith(
+      '前神社後面',
+      ['神社後'],
+      expect.any(Query)
+    )
+  })
+
+  it('keeps an attached mixed token as a legacy constraint without disabling other Han fallback', async () => {
+    const { engine } = await createEngine([
+      makeDocument('match.md', '周五的时候 foo中文bar'),
+      makeDocument('wrong-mixed.md', '周五的时候 foo其他bar'),
+    ])
+
+    await expect(search(engine, '时候 foo中文bar')).resolves.toEqual([
+      expect.objectContaining({ id: 'match.md' }),
+    ])
+  })
+
+  it('highlights the original long run instead of overlapping grams', async () => {
+    const { engine, plugin } = await createEngine([
+      makeDocument('true.md', '前甲乙丙后'),
+    ])
+
+    await engine.getSuggestions(query('甲乙丙'))
+    expect(plugin.textProcessor.getMatches).toHaveBeenCalledWith(
+      '前甲乙丙后',
+      ['甲乙丙'],
+      expect.any(Query)
+    )
+  })
+
+  it('rejects an unsigned cache and reuses a matching signed cache', async () => {
+    const documents = [makeDocument('example.md', '周五的时候')]
+    const { engine } = await createEngine(documents)
+    const cache = {
+      paths: engine.getSerializedIndexedDocuments(),
+      data: engine.getSerializedMiniSearch(),
+      indexSignature: engine.getIndexSignature(),
+    }
+
+    const unsignedPlugin = makePlugin(documents, {
+      ...cache,
+      indexSignature: undefined,
+    })
+    await expect(
+      new SearchEngine(
+        unsignedPlugin as unknown as OmnisearchPlugin
+      ).loadCache()
+    ).resolves.toBe(false)
+
+    const signedPlugin = makePlugin(documents, cache)
+    const loadedEngine = new SearchEngine(
+      signedPlugin as unknown as OmnisearchPlugin
+    )
+    await expect(loadedEngine.loadCache()).resolves.toBe(true)
+    await expect(search(loadedEngine, '时候')).resolves.toHaveLength(1)
+  })
+
+  it('falls back safely when Chs Patch throws', async () => {
+    const documents = [
+      makeDocument('example.md', 'projectA 周五的时候'),
+      makeDocument('mixed.md', 'foo中文bar'),
+    ]
+    const plugin = makePlugin(documents, null, {
+      manifest: { version: 'test' },
+      cut: () => {
+        throw new Error('segmenter failed')
+      },
+    })
+    const engine = new SearchEngine(plugin as unknown as OmnisearchPlugin)
+    await engine.addFromPaths(documents.map(document => document.path))
+
+    await expect(search(engine, 'projectA')).resolves.toHaveLength(1)
+    await expect(search(engine, '时候')).resolves.toHaveLength(1)
+
+    const cache = {
+      paths: engine.getSerializedIndexedDocuments(),
+      data: engine.getSerializedMiniSearch(),
+      indexSignature: engine.getIndexSignature(),
+    }
+    const healthyPlugin = makePlugin(documents, cache, {
+      manifest: { version: 'test' },
+      cut: (word: string) =>
+        word === 'foo中文bar' ? ['foo', '中文', 'bar'] : [word],
+    })
+    const healthyEngine = new SearchEngine(
+      healthyPlugin as unknown as OmnisearchPlugin
+    )
+    await expect(healthyEngine.loadCache()).resolves.toBe(false)
+    await healthyEngine.addFromPaths(documents.map(document => document.path))
+    await expect(search(healthyEngine, 'foo中文bar')).resolves.toEqual([
+      expect.objectContaining({ id: 'mixed.md' }),
+    ])
+  })
+})

--- a/src/__tests__/han-search-integration-tests.ts
+++ b/src/__tests__/han-search-integration-tests.ts
@@ -1,0 +1,131 @@
+import MiniSearch, { type QueryCombination } from 'minisearch'
+import {
+  HAN_GRAM_FIELDS,
+  ORIGINAL_SEARCH_FIELDS,
+  createHanQueryPlan,
+  documentContainsHanRuns,
+  getSourceFieldForHanGram,
+  isHanGramField,
+  tokenizeHanGramTerms,
+} from '../search/han-grams'
+
+type TestDocument = Record<(typeof ORIGINAL_SEARCH_FIELDS)[number], string> & {
+  id: string
+}
+
+const makeDocument = (
+  id: string,
+  content: string,
+  overrides: Partial<TestDocument> = {}
+): TestDocument => ({
+  id,
+  basename: id,
+  directory: '',
+  aliases: '',
+  content,
+  headings1: '',
+  headings2: '',
+  headings3: '',
+  ...overrides,
+})
+
+const createSearch = (documents: TestDocument[], withHanFields = true) => {
+  const fields = withHanFields
+    ? [...ORIGINAL_SEARCH_FIELDS, ...HAN_GRAM_FIELDS]
+    : [...ORIGINAL_SEARCH_FIELDS]
+  const miniSearch = new MiniSearch<TestDocument>({
+    idField: 'id',
+    fields,
+    extractField(document, field) {
+      const source = isHanGramField(field)
+        ? getSourceFieldForHanGram(field)
+        : field
+      return document[source as keyof TestDocument]
+    },
+    tokenize(text, field) {
+      return field && isHanGramField(field)
+        ? tokenizeHanGramTerms(text)
+        : text.split(/\s+/).filter(Boolean)
+    },
+    processTerm: term => term.toLowerCase(),
+  })
+  miniSearch.addAll(documents)
+  return miniSearch
+}
+
+const searchOptions = {
+  fields: [...ORIGINAL_SEARCH_FIELDS],
+  tokenize: (text: string) => [text],
+  processTerm: (term: string) => term.toLowerCase(),
+  prefix: true,
+  fuzzy: false,
+}
+
+const fallbackQuery = (text: string): QueryCombination => {
+  const plan = createHanQueryPlan(text)
+  if (!plan) throw new Error(`Missing Han query plan for ${text}`)
+
+  const queries: QueryCombination['queries'] = [
+    {
+      combineWith: 'AND',
+      queries: plan.grams,
+      fields: HAN_GRAM_FIELDS,
+      prefix: false,
+      fuzzy: false,
+    },
+  ]
+  const remaining = plan.remainingText.trim()
+  if (remaining) queries.unshift(remaining)
+  return { combineWith: 'AND', queries }
+}
+
+describe('Han fallback with MiniSearch', () => {
+  it('recalls an internal Han bigram while preserving a Latin constraint', () => {
+    const miniSearch = createSearch([
+      makeDocument('a', 'projectA 周五的时候'),
+      makeDocument('b', 'projectB 周五的时候'),
+    ])
+
+    expect(miniSearch.search('时候', searchOptions)).toHaveLength(0)
+    expect(
+      miniSearch
+        .search(fallbackQuery('projectA 时候'), searchOptions)
+        .map(result => String(result.id))
+    ).toEqual(['a'])
+  })
+
+  it('keeps ordinary field scores unchanged when Han fields are present', () => {
+    const documents = [
+      makeDocument('han', 'foo 周五的时候'),
+      makeDocument('latin', 'foo ordinary'),
+    ]
+    const baseline = createSearch(documents, false).search('foo', searchOptions)
+    const patched = createSearch(documents).search('foo', searchOptions)
+
+    expect(patched.map(result => [String(result.id), result.score])).toEqual(
+      baseline.map(result => [String(result.id), result.score])
+    )
+  })
+
+  it('treats multi-gram matches as candidates and rejects cross-field joins', () => {
+    const documents = [
+      makeDocument('true', '前甲乙丙后'),
+      makeDocument('cross-field', '乙丙', { basename: '甲乙' }),
+    ]
+    const miniSearch = createSearch(documents)
+    const candidates = miniSearch.search(fallbackQuery('甲乙丙'), searchOptions)
+    const verified = candidates.filter(result => {
+      const document = documents.find(item => item.id === String(result.id))!
+      return documentContainsHanRuns(
+        ['甲乙丙'],
+        ORIGINAL_SEARCH_FIELDS.map(field => document[field])
+      )
+    })
+
+    expect(candidates.map(result => String(result.id)).sort()).toEqual([
+      'cross-field',
+      'true',
+    ])
+    expect(verified.map(result => String(result.id))).toEqual(['true'])
+  })
+})

--- a/src/components/ModalInFile.svelte
+++ b/src/components/ModalInFile.svelte
@@ -31,6 +31,7 @@
   let selectedIndex = 0
   let note: ResultNote | undefined
   let query: Query
+  let searchAbortController: AbortController | null = null
 
   $: searchQuery = previousQuery ?? ''
 
@@ -45,21 +46,28 @@
   })
 
   onDestroy(() => {
+    searchAbortController?.abort()
     eventBus.disable('infile')
   })
 
   $: (async () => {
+    searchAbortController?.abort()
     if (searchQuery) {
+      const currentController = new AbortController()
+      searchAbortController = currentController
       query = new Query(searchQuery, {
         ignoreDiacritics: plugin.settings.ignoreDiacritics,
         ignoreArabicDiacritics: plugin.settings.ignoreArabicDiacritics,
       })
-      note =
+      const nextNote =
         (
           await plugin.searchEngine.getSuggestions(query, {
             singleFilePath,
+            signal: currentController.signal,
           })
         )[0] ?? null
+      if (currentController.signal.aborted) return
+      note = nextNote
     }
     selectedIndex = 0
     await scrollIntoView()

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -53,6 +53,7 @@
   let createInNewPaneKey: string = $state('')
   let createInCurrentPaneKey: string = $state('')
   let openInNewLeafKey: string = `${getCtrlKeyLabel()} ${getAltKeyLabel()} ↵`
+  let destroyed = false
 
   const selectedNote = $derived(resultNotes[selectedIndex])
 
@@ -74,6 +75,8 @@
     if (searchQuery) {
       updateResultsDebounced()
     } else {
+      updateResultsDebounced.cancel()
+      cancelActiveSearch()
       searching = false
       resultNotes = []
     }
@@ -114,10 +117,14 @@
     eventBus.on('vault', Action.NextSearchHistory, nextSearchHistory)
     eventBus.on('vault', Action.OpenInNewLeaf, openNoteInNewLeaf)
     await plugin.notesIndexer.refreshIndex()
+    if (destroyed) return
     await updateResultsDebounced()
   })
 
   onDestroy(() => {
+    destroyed = true
+    updateResultsDebounced.cancel()
+    cancelActiveSearch()
     eventBus.disable('vault')
   })
 
@@ -141,23 +148,37 @@
   }
 
   let cancelableQuery: CancelablePromise<ResultNote[]> | null = null
+  let searchAbortController: AbortController | null = null
+
+  function cancelActiveSearch() {
+    searchAbortController?.abort()
+    searchAbortController = null
+    cancelableQuery?.cancel()
+    cancelableQuery = null
+  }
+
   async function updateResults() {
     searching = true
     // If search is already in progress, cancel it and start a new one
-    if (cancelableQuery) {
-      cancelableQuery.cancel()
-      cancelableQuery = null
-    }
+    cancelActiveSearch()
     query = new Query(searchQuery, {
       ignoreDiacritics: plugin.settings.ignoreDiacritics,
       ignoreArabicDiacritics: plugin.settings.ignoreArabicDiacritics,
     })
+    searchAbortController = new AbortController()
+    const currentController = searchAbortController
     cancelableQuery = cancelable(
       new Promise(resolve => {
-        resolve(plugin.searchEngine.getSuggestions(query))
+        resolve(
+          plugin.searchEngine.getSuggestions(query, {
+            signal: currentController.signal,
+          })
+        )
       })
     )
-    resultNotes = await cancelableQuery
+    const nextResultNotes = await cancelableQuery
+    if (currentController.signal.aborted) return
+    resultNotes = nextResultNotes
     selectedIndex = 0
     await scrollIntoView()
     searching = false

--- a/src/database.ts
+++ b/src/database.ts
@@ -12,6 +12,7 @@ export class Database extends Dexie {
       date: string
       paths: DocumentRef[]
       data: AsPlainObject
+      indexSignature: string
     },
     string
   >
@@ -36,6 +37,7 @@ export class Database extends Dexie {
   public async getMinisearchCache(): Promise<{
     paths: DocumentRef[]
     data: AsPlainObject
+    indexSignature?: string
   } | null> {
     try {
       const cachedIndex = (await this.plugin.database.minisearch.toArray())[0]
@@ -59,6 +61,7 @@ export class Database extends Dexie {
       date: new Date().toISOString(),
       paths,
       data: minisearchJson,
+      indexSignature: this.plugin.searchEngine.getIndexSignature(),
     })
     console.debug('Omnisearch - Search cache written')
   }

--- a/src/search/han-grams.ts
+++ b/src/search/han-grams.ts
@@ -1,0 +1,203 @@
+export const HAN_NORMALIZATION = 'none' as const
+// Keep synthetic terms outside the namespace used by natural prefix searches.
+export const HAN_GRAM_PREFIX = '\uE000han:'
+
+export const ORIGINAL_SEARCH_FIELDS = [
+  'basename',
+  'directory',
+  'aliases',
+  'content',
+  'headings1',
+  'headings2',
+  'headings3',
+] as const
+
+export type OriginalSearchField = (typeof ORIGINAL_SEARCH_FIELDS)[number]
+
+export const HAN_GRAM_FIELD_BY_SOURCE = {
+  basename: 'hanGramsBasename',
+  directory: 'hanGramsDirectory',
+  aliases: 'hanGramsAliases',
+  content: 'hanGramsContent',
+  headings1: 'hanGramsHeadings1',
+  headings2: 'hanGramsHeadings2',
+  headings3: 'hanGramsHeadings3',
+} as const satisfies Record<OriginalSearchField, string>
+
+export type HanGramField =
+  (typeof HAN_GRAM_FIELD_BY_SOURCE)[OriginalSearchField]
+
+export const HAN_GRAM_FIELDS = Object.values(
+  HAN_GRAM_FIELD_BY_SOURCE
+) as HanGramField[]
+
+const SOURCE_FIELD_BY_HAN_GRAM = Object.fromEntries(
+  Object.entries(HAN_GRAM_FIELD_BY_SOURCE).map(([source, gramField]) => [
+    gramField,
+    source,
+  ])
+) as Record<HanGramField, OriginalSearchField>
+
+export const isHanGramField = (field: string): field is HanGramField =>
+  field in SOURCE_FIELD_BY_HAN_GRAM
+
+export const getSourceFieldForHanGram = (
+  field: HanGramField
+): OriginalSearchField => SOURCE_FIELD_BY_HAN_GRAM[field]
+
+export const HAN_INDEX_SCHEMA_VERSION = 1
+
+export type IndexSignatureOptions = {
+  tokenizeUrls: boolean
+  ignoreDiacritics: boolean
+  ignoreArabicDiacritics: boolean
+  chsPatch: string
+}
+
+export const createIndexSignature = (options: IndexSignatureOptions): string =>
+  JSON.stringify({
+    version: HAN_INDEX_SCHEMA_VERSION,
+    normalization: HAN_NORMALIZATION,
+    hanPolicy:
+      'Script=Han&General_Category=Letter|Mark|Number;marked-bigram;no-unigram',
+    gramMarker: HAN_GRAM_PREFIX,
+    originalFields: ORIGINAL_SEARCH_FIELDS,
+    gramFields: HAN_GRAM_FIELD_BY_SOURCE,
+    options,
+  })
+
+export type HanQueryPlan = {
+  runs: string[]
+  grams: string[]
+  remainingText: string
+}
+
+type TextSegment = {
+  value: string
+  isHan: boolean
+}
+
+const HAN_SCRIPT = /\p{Script=Han}/u
+const LETTER_MARK_OR_NUMBER = /[\p{Letter}\p{Mark}\p{Number}]/u
+const WORD_CHARACTER = /[\p{Letter}\p{Number}\p{Mark}]/u
+
+const normalize = (input: string): string => input
+
+export const isHanIndexCharacter = (character: string): boolean =>
+  HAN_SCRIPT.test(character) && LETTER_MARK_OR_NUMBER.test(character)
+
+const segmentText = (input: string): TextSegment[] => {
+  const segments: TextSegment[] = []
+  for (const character of input) {
+    const isHan = isHanIndexCharacter(character)
+    const previous = segments[segments.length - 1]
+    if (previous?.isHan === isHan) {
+      previous.value += character
+    } else {
+      segments.push({ value: character, isHan })
+    }
+  }
+  return segments
+}
+
+const firstCharacter = (input: string): string => Array.from(input)[0] ?? ''
+
+const lastCharacter = (input: string): string => {
+  const characters = Array.from(input)
+  return characters[characters.length - 1] ?? ''
+}
+
+const isAttachedToNonHanWord = (
+  segments: TextSegment[],
+  index: number
+): boolean => {
+  const previous = lastCharacter(segments[index - 1]?.value ?? '')
+  const next = firstCharacter(segments[index + 1]?.value ?? '')
+  return WORD_CHARACTER.test(previous) || WORD_CHARACTER.test(next)
+}
+
+export const extractHanRuns = (input: string): string[] =>
+  segmentText(input)
+    .filter(segment => segment.isHan)
+    .map(segment => normalize(segment.value))
+
+export const tokenizeHanBigrams = (input: string): string[] => {
+  const grams: string[] = []
+  let previousHan = ''
+  for (const character of input) {
+    if (!isHanIndexCharacter(character)) {
+      previousHan = ''
+      continue
+    }
+    if (previousHan) grams.push(previousHan + character)
+    previousHan = character
+  }
+  return grams
+}
+
+export const markHanGram = (gram: string): string => HAN_GRAM_PREFIX + gram
+
+export const tokenizeHanGramTerms = (input: string): string[] =>
+  tokenizeHanBigrams(input).map(markHanGram)
+
+export const createHanQueryPlan = (input: string): HanQueryPlan | null => {
+  const segments = segmentText(input)
+  const eligibleIndexes = segments
+    .map((segment, index) => ({ segment, index }))
+    .filter(
+      ({ segment, index }) =>
+        segment.isHan &&
+        Array.from(segment.value).length > 1 &&
+        !isAttachedToNonHanWord(segments, index)
+    )
+    .map(({ index }) => index)
+
+  if (!eligibleIndexes.length) return null
+
+  const eligible = new Set(eligibleIndexes)
+  const runs = eligibleIndexes.map(index => normalize(segments[index].value))
+  return {
+    runs,
+    grams: [...new Set(runs.flatMap(tokenizeHanGramTerms))],
+    remainingText: segments
+      .map((segment, index) =>
+        eligible.has(index)
+          ? ' '.repeat(Array.from(segment.value).length)
+          : segment.value
+      )
+      .join(''),
+  }
+}
+
+export const documentContainsHanRuns = (
+  runs: string[],
+  fieldValues: readonly string[]
+): boolean => {
+  const normalizedFields = fieldValues.map(normalize)
+  return runs
+    .map(normalize)
+    .every(run => normalizedFields.some(fieldValue => fieldValue.includes(run)))
+}
+
+export const requiresHanVerification = (runs: string[]): boolean =>
+  runs.some(run => Array.from(run).length > 2)
+
+type RankedResult = {
+  id: string
+  score: number
+}
+
+export const reconcileVerifiedHanResults = <T extends RankedResult>(
+  naturalResults: T[],
+  combinedResults: T[],
+  verifiedFallbackIds: ReadonlySet<string>
+): T[] => {
+  const naturalById = new Map(naturalResults.map(result => [result.id, result]))
+  return combinedResults
+    .flatMap(result => {
+      if (verifiedFallbackIds.has(result.id)) return [result]
+      const naturalResult = naturalById.get(result.id)
+      return naturalResult ? [naturalResult] : []
+    })
+    .sort((a, b) => b.score - a.score)
+}

--- a/src/search/query.ts
+++ b/src/search/query.ts
@@ -4,7 +4,7 @@ import { parse } from 'search-query-parser'
 const keywords = ['ext', 'path'] as const
 
 type Keywords = {
-  [K in typeof keywords[number]]?: string[]
+  [K in (typeof keywords)[number]]?: string[]
 } & { text: string[] }
 
 export class Query {
@@ -12,8 +12,15 @@ export class Query {
     exclude: Keywords
   }
   #inQuotes: string[]
+  #rawInput: string
+  #rawText?: string[]
 
-  constructor(text = '', options: { ignoreDiacritics: boolean, ignoreArabicDiacritics: boolean}) {
+  constructor(
+    text = '',
+    options: { ignoreDiacritics: boolean; ignoreArabicDiacritics: boolean }
+  ) {
+    this.#rawInput = text
+
     if (options.ignoreDiacritics) {
       text = removeDiacritics(text, options.ignoreArabicDiacritics)
     }
@@ -73,6 +80,20 @@ export class Query {
 
   public segmentsToStr(): string {
     return this.query.text.join(' ')
+  }
+
+  public rawSegmentsToStr(): string {
+    if (!this.#rawText) {
+      const rawParsed = parse(this.#rawInput.toLowerCase(), {
+        tokenize: true,
+        keywords: keywords as unknown as string[],
+      }) as unknown as typeof this.query
+      const rawText = rawParsed.text ?? []
+      this.#rawText = (Array.isArray(rawText) ? rawText : [rawText]).filter(
+        value => !value.startsWith('.')
+      )
+    }
+    return this.#rawText.join(' ')
   }
 
   public getTags(): string[] {

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -1,6 +1,8 @@
 import MiniSearch, {
   type AsPlainObject,
   type Options,
+  type QueryCombination,
+  type SearchOptions,
   type SearchResult,
 } from 'minisearch'
 import {
@@ -21,6 +23,18 @@ import type { Query } from './query'
 import { sortBy } from 'es-toolkit/compat'
 import type OmnisearchPlugin from '../main'
 import { Tokenizer } from './tokenizer'
+import {
+  HAN_GRAM_FIELD_BY_SOURCE,
+  HAN_GRAM_FIELDS,
+  ORIGINAL_SEARCH_FIELDS,
+  documentContainsHanRuns,
+  getSourceFieldForHanGram,
+  isHanGramField,
+  reconcileVerifiedHanResults,
+  requiresHanVerification,
+} from './han-grams'
+
+type SearchResultWithHan = SearchResult & { hanQueryRuns?: string[] }
 
 export class SearchEngine {
   private tokenizer: Tokenizer
@@ -43,6 +57,10 @@ export class SearchEngine {
     await this.plugin.embedsRepository.loadFromCache()
     const cache = await this.plugin.database.getMinisearchCache()
     if (cache) {
+      if (cache.indexSignature !== this.getIndexSignature()) {
+        logVerbose('Search cache index signature changed')
+        return false
+      }
       this.minisearch = await MiniSearch.loadJSAsync(
         cache.data,
         this.getOptions()
@@ -134,10 +152,14 @@ export class SearchEngine {
    */
   public async search(
     query: Query,
-    options: { prefixLength: number; singleFilePath?: string }
+    options: {
+      prefixLength: number
+      singleFilePath?: string
+      signal?: AbortSignal
+    }
   ): Promise<SearchResult[]> {
     const settings = this.plugin.settings
-    if (query.isEmpty()) {
+    if (query.isEmpty() || options.signal?.aborted) {
       // this.previousResults = []
       // this.previousQuery = null
       return []
@@ -159,9 +181,16 @@ export class SearchEngine {
         break
     }
 
-    const searchTokens = this.tokenizer.tokenizeForSearch(query.segmentsToStr())
-    logVerbose(JSON.stringify(searchTokens, null, 1))
-    let results = this.minisearch.search(searchTokens, {
+    const naturalQuery = this.tokenizer.tokenizeForSearch(query.segmentsToStr())
+    const hanSearch = this.tokenizer.tokenizeForHanSearch(
+      query.segmentsToStr(),
+      () => query.rawSegmentsToStr()
+    )
+    logVerbose(JSON.stringify(naturalQuery, null, 1))
+    if (hanSearch) logVerbose(JSON.stringify(hanSearch.query, null, 1))
+
+    const miniSearchOptions: SearchOptions = {
+      fields: [...ORIGINAL_SEARCH_FIELDS],
       prefix: term => term.length >= options.prefixLength,
       // length <= 3: no fuzziness
       // length <= 5: fuzziness of 10%
@@ -178,6 +207,13 @@ export class SearchEngine {
         headings3: settings.weightH3,
         tags: settings.weightUnmarkedTags,
         unmarkedTags: settings.weightUnmarkedTags,
+        [HAN_GRAM_FIELD_BY_SOURCE.basename]: settings.weightBasename,
+        [HAN_GRAM_FIELD_BY_SOURCE.directory]: settings.weightDirectory,
+        [HAN_GRAM_FIELD_BY_SOURCE.aliases]: settings.weightBasename,
+        [HAN_GRAM_FIELD_BY_SOURCE.content]: 1,
+        [HAN_GRAM_FIELD_BY_SOURCE.headings1]: settings.weightH1,
+        [HAN_GRAM_FIELD_BY_SOURCE.headings2]: settings.weightH2,
+        [HAN_GRAM_FIELD_BY_SOURCE.headings3]: settings.weightH3,
       },
       // The query is already tokenized, don't tokenize again
       tokenize: text => [text],
@@ -203,44 +239,35 @@ export class SearchEngine {
           1 + Math.exp(cutoff[settings.recencyBoost] * (daysElapsed / 1000))
         )
       },
-    })
+    }
+
+    let results = hanSearch
+      ? await this.searchWithHanFallback(
+          naturalQuery,
+          hanSearch,
+          query,
+          options.singleFilePath,
+          options.signal,
+          miniSearchOptions
+        )
+      : this.minisearch.search(naturalQuery, miniSearchOptions)
+
+    if (options.signal?.aborted) return []
 
     logVerbose(`Found ${results.length} results`, results)
 
-    // Filter query results to only keep files that match query.query.ext (if any)
-    if (query.query.ext?.length) {
-      results = results.filter(r => {
-        // ".can" should match ".canvas"
-        const ext = '.' + r.id.split('.').pop()
-        return query.query.ext?.some(e =>
-          ext.startsWith(e.startsWith('.') ? e : '.' + e)
-        )
-      })
-    }
-
-    // Filter query results that match the path
-    if (query.query.path) {
-      results = results.filter(r =>
-        query.query.path?.some(p =>
-          (r.id as string).toLowerCase().includes(p.toLowerCase())
-        )
-      )
-    }
-    if (query.query.exclude.path) {
-      results = results.filter(
-        r =>
-          !query.query.exclude.path?.some(p =>
-            (r.id as string).toLowerCase().includes(p.toLowerCase())
-          )
-      )
-    }
+    results = this.filterByQueryPath(results, query)
 
     if (!results.length) {
       return []
     }
 
     if (options.singleFilePath) {
-      return results.filter(r => r.id === options.singleFilePath)
+      return this.filterByDocumentSemantics(
+        results.filter(r => r.id === options.singleFilePath),
+        query,
+        options.signal
+      )
     }
 
     logVerbose(
@@ -330,47 +357,11 @@ export class SearchEngine {
 
     if (results.length) logVerbose('First result:', results[0])
 
-    const documents = await Promise.all(
-      results.map(async result => {
-        const doc = await this.plugin.documentsRepository.getDocument(result.id)
-        if (!doc) {
-          console.warn(`Omnisearch - Note "${result.id}" not in the live cache`)
-          countError(true)
-        }
-        return doc
-      })
+    results = await this.filterByDocumentSemantics(
+      results,
+      query,
+      options.signal
     )
-
-    // If the search query contains quotes, filter out results that don't have the exact match
-    const exactTerms = query.getExactTerms()
-    if (exactTerms.length) {
-      logVerbose('Filtering with quoted terms: ', exactTerms)
-      results = results.filter(r => {
-        const document = documents.find(d => d.path === r.id)
-        const title = document?.path.toLowerCase() ?? ''
-        const content = (document?.cleanedContent ?? '').toLowerCase()
-        return exactTerms.every(
-          q =>
-            content.includes(q) ||
-            removeDiacritics(
-              title,
-              this.plugin.settings.ignoreArabicDiacritics
-            ).includes(q)
-        )
-      })
-    }
-
-    // If the search query contains exclude terms, filter out results that have them
-    const exclusions = query.query.exclude.text
-    if (exclusions.length) {
-      logVerbose('Filtering with exclusions')
-      results = results.filter(r => {
-        const content = (
-          documents.find(d => d.path === r.id)?.content ?? ''
-        ).toLowerCase()
-        return exclusions.every(q => !content.includes(q))
-      })
-    }
 
     logVerbose('Deduping')
     // FIXME:
@@ -395,7 +386,7 @@ export class SearchEngine {
    */
   public async getSuggestions(
     query: Query,
-    options?: Partial<{ singleFilePath?: string }>
+    options?: { singleFilePath?: string; signal?: AbortSignal }
   ): Promise<ResultNote[]> {
     // Get the raw results
     let results: SearchResult[]
@@ -403,13 +394,17 @@ export class SearchEngine {
       results = await this.search(query, {
         prefixLength: 3,
         singleFilePath: options?.singleFilePath,
+        signal: options?.signal,
       })
     } else {
       results = await this.search(query, {
         prefixLength: 1,
         singleFilePath: options?.singleFilePath,
+        signal: options?.signal,
       })
     }
+
+    if (options?.signal?.aborted) return []
 
     const documents = await Promise.all(
       results.map(
@@ -417,10 +412,12 @@ export class SearchEngine {
           await this.plugin.documentsRepository.getDocument(result.id)
       )
     )
+    if (options?.signal?.aborted) return []
 
     // Inject embeds for images, documents, and PDFs
     let total = documents.length
     for (let i = 0; i < total; i++) {
+      if (options?.signal?.aborted) return []
       const doc = documents[i]
       if (!doc) continue
 
@@ -430,8 +427,10 @@ export class SearchEngine {
 
       // Inject embeds in the results
       for (const embed of embeds) {
+        if (options?.signal?.aborted) return []
         total++
         const newDoc = await this.plugin.documentsRepository.getDocument(embed)
+        if (options?.signal?.aborted) return []
         documents.splice(i + 1, 0, newDoc)
         results.splice(i + 1, 0, {
           id: newDoc.path,
@@ -461,16 +460,25 @@ export class SearchEngine {
 
       // Clean search matches that match quoted expressions,
       // and inject those expressions instead
+      const hanQueryRuns = (result as SearchResultWithHan).hanQueryRuns ?? []
+      const naturalTerms = result.terms.filter(
+        term => !result.match[term]?.some(field => isHanGramField(field))
+      )
       const foundWords = [
-        // Matching terms from the result,
-        // do not necessarily match the query
-        ...result.terms,
+        ...new Set([
+          // Use the original query run for fallback excerpts/highlights.
+          ...hanQueryRuns,
 
-        // Quoted expressions
-        ...query.getExactTerms(),
+          // Matching terms from the result,
+          // do not necessarily match the query
+          ...naturalTerms,
 
-        // Tags, starting with #
-        ...query.getTags(),
+          // Quoted expressions
+          ...query.getExactTerms(),
+
+          // Tags, starting with #
+          ...query.getTags(),
+        ]),
       ]
       logVerbose('Matching tokens:', foundWords)
 
@@ -513,34 +521,27 @@ export class SearchEngine {
     }))
   }
 
+  public getIndexSignature(): string {
+    return this.tokenizer.getIndexSignature()
+  }
+
   private getOptions(): Options<IndexedDocument> {
     return {
       tokenize: this.tokenizer.tokenizeForIndexing.bind(this.tokenizer),
-      extractField: (doc, fieldName) => {
-        if (fieldName === 'directory') {
-          // return path without the filename
-          const parts = doc.path.split('/')
-          parts.pop()
-          return parts.join('/')
-        }
-        return (doc as any)[fieldName]
-      },
-      processTerm: (term: string) =>
-        (this.plugin.settings.ignoreDiacritics
-          ? removeDiacritics(term, this.plugin.settings.ignoreArabicDiacritics)
-          : term
+      extractField: (doc, fieldName) =>
+        this.extractDocumentField(doc, fieldName),
+      processTerm: (term: string, fieldName?: string) =>
+        (fieldName && isHanGramField(fieldName)
+          ? term
+          : this.plugin.settings.ignoreDiacritics
+            ? removeDiacritics(
+                term,
+                this.plugin.settings.ignoreArabicDiacritics
+              )
+            : term
         ).toLowerCase(),
       idField: 'path',
-      fields: [
-        'basename',
-        // Different from `path`, since `path` is the unique index and needs to include the filename
-        'directory',
-        'aliases',
-        'content',
-        'headings1',
-        'headings2',
-        'headings3',
-      ],
+      fields: [...ORIGINAL_SEARCH_FIELDS, ...HAN_GRAM_FIELDS],
       storeFields: ['tags', 'mtime'],
       logger(_level, _message, code) {
         if (code === 'version_conflict') {
@@ -551,5 +552,200 @@ export class SearchEngine {
         }
       },
     }
+  }
+
+  private extractDocumentField(
+    document: IndexedDocument,
+    fieldName: string
+  ): string {
+    // MiniSearch's extractField type says string, but stored fields retain their
+    // original runtime values and are not sent through the tokenizer.
+    if (fieldName === 'tags') return document.tags as unknown as string
+    if (fieldName === 'mtime') return document.mtime as unknown as string
+
+    const sourceField = isHanGramField(fieldName)
+      ? getSourceFieldForHanGram(fieldName)
+      : fieldName
+    if (sourceField === 'directory') {
+      const parts = document.path.split('/')
+      parts.pop()
+      return parts.join('/')
+    }
+    const value = document[sourceField as keyof IndexedDocument]
+    return Array.isArray(value) ? value.join(' ') : String(value ?? '')
+  }
+
+  private async filterByDocumentSemantics(
+    results: SearchResult[],
+    query: Query,
+    signal?: AbortSignal
+  ): Promise<SearchResult[]> {
+    const documents = await Promise.all(
+      results.map(async result => {
+        const document = await this.plugin.documentsRepository.getDocument(
+          result.id
+        )
+        if (!document) {
+          console.warn(`Omnisearch - Note "${result.id}" not in the live cache`)
+          countError(true)
+        }
+        return document
+      })
+    )
+    if (signal?.aborted) return []
+
+    const exactTerms = query.getExactTerms()
+    if (exactTerms.length) {
+      logVerbose('Filtering with quoted terms: ', exactTerms)
+      results = results.filter(result => {
+        const document = documents.find(item => item.path === result.id)
+        const title = document?.path.toLowerCase() ?? ''
+        const content = (document?.cleanedContent ?? '').toLowerCase()
+        return exactTerms.every(
+          term =>
+            content.includes(term) ||
+            removeDiacritics(
+              title,
+              this.plugin.settings.ignoreArabicDiacritics
+            ).includes(term)
+        )
+      })
+    }
+
+    const exclusions = query.query.exclude.text
+    if (exclusions.length) {
+      logVerbose('Filtering with exclusions')
+      results = results.filter(result => {
+        const content = (
+          documents.find(item => item.path === result.id)?.content ?? ''
+        ).toLowerCase()
+        return exclusions.every(term => !content.includes(term))
+      })
+    }
+
+    return results
+  }
+
+  private filterByQueryPath<T extends SearchResult>(
+    results: T[],
+    query: Query
+  ): T[] {
+    if (query.query.ext?.length) {
+      results = results.filter(result => {
+        const ext = '.' + String(result.id).split('.').pop()
+        return query.query.ext?.some(value =>
+          ext.startsWith(value.startsWith('.') ? value : '.' + value)
+        )
+      })
+    }
+    if (query.query.path) {
+      results = results.filter(result =>
+        query.query.path?.some(path =>
+          String(result.id).toLowerCase().includes(path.toLowerCase())
+        )
+      )
+    }
+    if (query.query.exclude.path) {
+      results = results.filter(
+        result =>
+          !query.query.exclude.path?.some(path =>
+            String(result.id).toLowerCase().includes(path.toLowerCase())
+          )
+      )
+    }
+    return results
+  }
+
+  private async searchWithHanFallback(
+    naturalQuery: QueryCombination,
+    hanSearch: { query: QueryCombination; runs: string[] },
+    query: Query,
+    singleFilePath: string | undefined,
+    signal: AbortSignal | undefined,
+    miniSearchOptions: SearchOptions
+  ): Promise<SearchResultWithHan[]> {
+    const combinedQuery: QueryCombination = {
+      combineWith: 'OR',
+      queries: [naturalQuery, hanSearch.query],
+    }
+    if (!requiresHanVerification(hanSearch.runs)) {
+      return this.markHanResults(
+        this.minisearch.search(combinedQuery, miniSearchOptions),
+        hanSearch.runs
+      )
+    }
+
+    const naturalResults = this.minisearch.search(
+      naturalQuery,
+      miniSearchOptions
+    )
+    let fallbackCandidates = this.filterByQueryPath(
+      this.minisearch.search(hanSearch.query, miniSearchOptions),
+      query
+    )
+    if (singleFilePath) {
+      fallbackCandidates = fallbackCandidates.filter(
+        result => result.id === singleFilePath
+      )
+    }
+    const verifiedFallbackIds = await this.verifyHanCandidates(
+      fallbackCandidates,
+      hanSearch.runs,
+      signal
+    )
+    if (!verifiedFallbackIds) return []
+    const combinedResults = this.minisearch.search(
+      combinedQuery,
+      miniSearchOptions
+    )
+    return this.markHanResults(
+      reconcileVerifiedHanResults(
+        naturalResults,
+        combinedResults,
+        verifiedFallbackIds
+      ),
+      hanSearch.runs
+    )
+  }
+
+  private async verifyHanCandidates(
+    results: SearchResult[],
+    runs: string[],
+    signal?: AbortSignal
+  ): Promise<Set<string> | null> {
+    const verified = new Set<string>()
+    for (const chunk of chunkArray(results, 50)) {
+      if (signal?.aborted) return null
+      const documents = await Promise.all(
+        chunk.map(result =>
+          this.plugin.documentsRepository.getDocument(String(result.id))
+        )
+      )
+      documents.forEach((document, index) => {
+        if (!document) return
+        const fieldValues = ORIGINAL_SEARCH_FIELDS.map(field =>
+          String(this.extractDocumentField(document, field) ?? '')
+        )
+        if (documentContainsHanRuns(runs, fieldValues)) {
+          verified.add(String(chunk[index].id))
+        }
+      })
+      if (signal?.aborted) return null
+    }
+    return verified
+  }
+
+  private markHanResults(
+    results: SearchResultWithHan[],
+    runs: string[]
+  ): SearchResultWithHan[] {
+    results.forEach(result => {
+      if (
+        Object.values(result.match).some(fields => fields.some(isHanGramField))
+      ) {
+        result.hanQueryRuns = runs
+      }
+    })
+    return results
   }
 }

--- a/src/search/tokenizer.ts
+++ b/src/search/tokenizer.ts
@@ -2,10 +2,24 @@ import type { QueryCombination } from 'minisearch'
 import { BRACKETS_AND_SPACE, chsRegex, SPACE_OR_PUNCTUATION } from '../globals'
 import { logVerbose, splitCamelCase, splitHyphens } from '../tools/utils'
 import type OmnisearchPlugin from '../main'
+import {
+  HAN_GRAM_FIELDS,
+  createHanQueryPlan,
+  createIndexSignature,
+  isHanGramField,
+  tokenizeHanGramTerms,
+} from './han-grams'
 
 const markdownLinkExtractor = require('markdown-link-extractor')
 
+type ChsSegmenter = {
+  manifest?: { version?: unknown }
+  cut: (word: string, options: { search: true }) => unknown
+}
+
 export class Tokenizer {
+  private chsPatchDegraded = false
+
   constructor(private plugin: OmnisearchPlugin) {}
 
   /**
@@ -14,7 +28,11 @@ export class Tokenizer {
    * @param text
    * @returns
    */
-  public tokenizeForIndexing(text: string): string[] {
+  public tokenizeForIndexing(text: string, fieldName?: string): string[] {
+    if (fieldName && isHanGramField(fieldName)) {
+      return tokenizeHanGramTerms(text)
+    }
+
     try {
       const words = this.tokenizeWords(text)
       let urls: string[] = []
@@ -27,11 +45,14 @@ export class Tokenizer {
       }
 
       let tokens = this.tokenizeTokens(text, { skipChs: true })
-      tokens = [...tokens.flatMap(token => [
-        token,
-        ...splitHyphens(token),
-        ...splitCamelCase(token),
-      ]), ...words]
+      tokens = [
+        ...tokens.flatMap(token => [
+          token,
+          ...splitHyphens(token),
+          ...splitCamelCase(token),
+        ]),
+        ...words,
+      ]
 
       // Add urls
       if (urls.length) {
@@ -40,7 +61,7 @@ export class Tokenizer {
 
       // Remove duplicates
       // tokens = [...new Set(tokens)]
-      
+
       // Remove empty tokens
       tokens = tokens.filter(Boolean)
 
@@ -58,10 +79,70 @@ export class Tokenizer {
    * @returns
    */
   public tokenizeForSearch(text: string): QueryCombination {
-    // Extract urls and remove them from the query
-    const urls: string[] = markdownLinkExtractor(text)
-    text = urls.reduce((acc, url) => acc.replace(url, ''), text)
+    const { textWithoutUrls, urls } = this.extractUrls(text)
+    return this.buildNaturalQuery(textWithoutUrls, urls)
+  }
 
+  public tokenizeForHanSearch(
+    text: string,
+    getRawText: () => string = () => text
+  ): { query: QueryCombination; runs: string[] } | null {
+    if (!createHanQueryPlan(text)) return null
+
+    const { textWithoutUrls, urls } = this.extractUrls(text)
+    const normalizedPlan = createHanQueryPlan(textWithoutUrls)
+    if (!normalizedPlan) return null
+
+    const rawTextWithoutUrls = this.extractUrls(getRawText()).textWithoutUrls
+    const plan = createHanQueryPlan(rawTextWithoutUrls)
+    if (!plan || plan.runs.length !== normalizedPlan.runs.length) {
+      return null
+    }
+
+    const queries: QueryCombination['queries'] = []
+    const naturalQuery = this.buildNaturalQuery(
+      normalizedPlan.remainingText,
+      urls
+    )
+    if (this.hasQueryTerms(naturalQuery)) queries.push(naturalQuery)
+    queries.push({
+      combineWith: 'AND',
+      queries: plan.grams,
+      fields: HAN_GRAM_FIELDS,
+      prefix: false,
+      fuzzy: false,
+      processTerm: term => term.toLowerCase(),
+    })
+
+    return {
+      query: { combineWith: 'AND', queries },
+      runs: plan.runs,
+    }
+  }
+
+  public getIndexSignature(): string {
+    const segmenter = this.getChsSegmenter()
+    const chsPatch = segmenter ? this.getChsPatchSignature(segmenter) : 'absent'
+    return createIndexSignature({
+      tokenizeUrls: this.plugin.settings.tokenizeUrls,
+      ignoreDiacritics: this.plugin.settings.ignoreDiacritics,
+      ignoreArabicDiacritics: this.plugin.settings.ignoreArabicDiacritics,
+      chsPatch,
+    })
+  }
+
+  private extractUrls(text: string): {
+    textWithoutUrls: string
+    urls: string[]
+  } {
+    const urls: string[] = markdownLinkExtractor(text)
+    return {
+      textWithoutUrls: urls.reduce((acc, url) => acc.replace(url, ''), text),
+      urls,
+    }
+  }
+
+  private buildNaturalQuery(text: string, urls: string[]): QueryCombination {
     const tokens = [...this.tokenizeTokens(text), ...urls].filter(Boolean)
 
     return {
@@ -78,6 +159,14 @@ export class Tokenizer {
     }
   }
 
+  private hasQueryTerms(query: QueryCombination): boolean {
+    return query.queries.some(subquery => {
+      if (typeof subquery === 'string') return Boolean(subquery)
+      if (typeof subquery === 'symbol') return true
+      return this.hasQueryTerms(subquery)
+    })
+  }
+
   private tokenizeWords(text: string, { skipChs = false } = {}): string[] {
     const tokens = text.split(BRACKETS_AND_SPACE)
     if (skipChs) return tokens
@@ -91,10 +180,54 @@ export class Tokenizer {
   }
 
   private tokenizeChsWord(tokens: string[]): string[] {
-    const segmenter = this.plugin.getChsSegmenter()
+    const segmenter = this.getChsSegmenter()
     if (!segmenter) return tokens
-    return tokens.flatMap(word =>
-      chsRegex.test(word) ? segmenter.cut(word, { search: true }) : [word]
+    return tokens.flatMap(word => {
+      if (!chsRegex.test(word)) return [word]
+      try {
+        const segmented = segmenter.cut(word, { search: true })
+        const validTokens = this.getValidChsTokens(segmented)
+        if (validTokens) return validTokens
+        this.chsPatchDegraded = true
+        return [word]
+      } catch (error) {
+        this.chsPatchDegraded = true
+        logVerbose('Error tokenizing Chinese word, using fallback', error)
+        return [word]
+      }
+    })
+  }
+
+  private getValidChsTokens(segmented: unknown): string[] | null {
+    if (!Array.isArray(segmented)) return null
+    const validTokens = segmented.filter(
+      (token): token is string => typeof token === 'string' && !!token
     )
+    return validTokens.length ? validTokens : null
+  }
+
+  private getChsPatchSignature(segmenter: ChsSegmenter): string {
+    const version = segmenter.manifest?.version
+    const versionLabel =
+      typeof version === 'string' && version ? version : 'unknown-version'
+    if (!this.chsPatchDegraded) {
+      try {
+        this.chsPatchDegraded = !this.getValidChsTokens(
+          segmenter.cut('中文', { search: true })
+        )
+      } catch {
+        this.chsPatchDegraded = true
+      }
+    }
+    return `${versionLabel}:${this.chsPatchDegraded ? 'degraded' : 'ready'}`
+  }
+
+  private getChsSegmenter(): ChsSegmenter | undefined {
+    const segmenter = this.plugin.getChsSegmenter() as unknown
+    if (!segmenter || typeof segmenter !== 'object') return undefined
+    const candidate = segmenter as Partial<ChsSegmenter>
+    return typeof candidate.cut === 'function'
+      ? (candidate as ChsSegmenter)
+      : undefined
   }
 }


### PR DESCRIPTION
Closes #558.

## Summary

Without a compatible token from the optional Chinese Support Patch, a continuous Han span such as `周五的时候` is indexed as one MiniSearch term. Prefix search finds `周五`, but the exact internal substring `时候` is missed.

This adds a dependency-free Han substring fallback while preserving the existing tokenizer, Chinese Support Patch tokens, MiniSearch ranking, and ordinary-query behavior.

## Implementation

- Index overlapping Han bigrams in private fields that mirror the seven searchable fields. Grams never cross field boundaries.
- Use the fallback only for Han runs of at least two code points, with exact, non-prefix, non-fuzzy lookup. The fallback is ANDed with the existing natural-query branch.
- Treat a two-character posting as exact. For longer runs, verify every candidate against the original field before sorting and top-50 truncation.
- Highlight the original query run, not synthetic grams.
- Cancel stale candidate/result/embed hydration with `AbortSignal`.
- Add an index signature covering the gram schema, token-affecting settings, and Chinese Support Patch version plus `ready`/`degraded` state, so incompatible caches rebuild automatically.

No dependency was added. This first version is Han-only and does not add single-character infix matching, broaden attached mixed-script tokens such as `foo中文bar`, or claim full Japanese/Korean support.

## Validation

Three focused suites pass 27/27 tests, covering the reported case, Unicode Han variants, punctuation, separated/cross-field false candidates, 60 false candidates ahead of a true result, Latin constraints, cache transitions, highlighting, and cancellation. Mixed, zero-Han, and Han-heavy comparisons preserve ordinary-query IDs, order, and numeric scores exactly.

`pnpm build`, `pnpm check`, and TypeScript checks pass with the existing `previousQuery` warning. New files have zero ESLint errors; the changed legacy scope has 37 errors versus 49 at baseline. The repository's default Jest command still stops before discovery because its configured `jest-environment-jsdom` package is undeclared. Modal lifecycle changes were source-reviewed and Svelte-compiled rather than claimed as component tests.

## Performance

Local Node 26 / MiniSearch 7.1 benchmarks used 10,000 deterministic documents, three build rounds, 500 query samples, and 100 fresh-file simulations per profile. Each accepted run passed a 90-second low-load/no-compiler gate plus post-run, source-stability, correctness, and build-spread checks.

| Profile | Build p50 base → patch | Cache ratio | Retained-heap ratio | 2-char / cached 3+ / fresh-file p99 |
|---|---:|---:|---:|---:|
| mixed (27.78% Han) | 251 → 822 ms | 2.26× | 1.89× | 0.130 / 0.334 / 5.409 ms |
| zero-Han | 117 → 150 ms | 1.05× | 1.001× | 0.012 / 0.008 / 0.048 ms |
| Han-heavy (51.14% Han) | 173 → 810 ms | 2.81× | 2.42× | 0.084 / 0.215 / 4.063 ms |

Mixed and Han-heavy each recall 666/666 two-character matches and 323/323 verified longer matches; verification removes 343 false candidates with no miss. The production bundle increases by 0.91% raw and 0.88% with `gzip -n -c`.

These are synthetic V8 measurements, not Obsidian mobile, IndexedDB, real-vault, or physical cold-disk results. The indexing and memory cost for Han-heavy vaults is intentionally called out.
