### PR TITLE
Fixed case-sensitive excerpt anchoring for quoted queries

### DIFF
--- a/src/tools/text-processing.ts
+++ b/src/tools/text-processing.ts
@@ -113,11 +113,15 @@ export class TextProcessor {
       query &&
       (query.query.text.length > 1 || query.getExactTerms().length > 0)
     ) {
-      const best = text.indexOf(query.getBestStringForExcerpt())
+      const excerptString = query.getBestStringForExcerpt()
+      // Matched case-insensitively via regex rather than by lowercasing `text`,
+      // because toLowerCase() is not length-preserving across all of Unicode and
+      // would desynchronise `best` from the offsets collected above.
+      const best = text.search(new RegExp(escapeRegExp(excerptString), 'iu'))
       if (best > -1 && matches.find(m => m.offset === best)) {
         matches.unshift({
           offset: best,
-          match: query.getBestStringForExcerpt(),
+          match: excerptString,
         })
       }
     }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<p>Quoted queries whose capitalisation differs from the note body return the correct files, but the excerpt is anchored to the wrong offset and the match count is one lower than it should be. The cause is a single case-sensitive <code>indexOf</code> in <code>TextProcessor.getMatches()</code>. Retrieval, scoring, filtering and highlighting are all already case-insensitive, so this affects presentation only.</p>
<h2 data-heading="Reproduction">Reproduction</h2>
<p>Given a note with frontmatter and the phrase appearing in lower case in the body, some way past the start of the file.</p>
<p>Run two vault searches in succession:</p>

Query | Result
-- | --
"one two three" | Correct files. Excerpt anchored on the phrase. N matches.
"One Two Three" | Same files, same order. Excerpt anchored on the frontmatter. N - 1 matches.


<p>The off-by-one in the match count is the most reliable signal, since it does not depend on judging excerpts by eye. It reproduces consistently across every result in the list.</p>
<h2 data-heading="Cause">Cause</h2>
<p><code>Query</code>'s constructor extracts quoted expressions from the raw query string, before any case folding is applied:</p>
<pre><code class="language-ts">this.#inQuotes =
  text.match(/"([^"]+)"/g)?.map(o => o.replace(/"/g, '')) ?? []
</code></pre>
<p><code>getExactTerms()</code> lowercases its return value, so the quoted-phrase filter in <code>SearchEngine</code> is unaffected. <code>getBestStringForExcerpt()</code> returns <code>#inQuotes</code> verbatim, and in <code>TextProcessor.getMatches()</code> that value is handed to <code>String.prototype.indexOf</code> against case-preserved note content:</p>
<pre><code class="language-ts">const best = text.indexOf(query.getBestStringForExcerpt())
if (best > -1 &#x26;&#x26; matches.find(m => m.offset === best)) {
  matches.unshift({ offset: best, match: query.getBestStringForExcerpt() })
}
</code></pre>
<p>Whenever the query's capitalisation differs from the note's, <code>best</code> is <code>-1</code> and the <code>unshift</code> never fires. That produces both symptoms:</p>
<ol>
<li>The <code>matches</code> array is one element shorter, which surfaces directly as the "N matches" count in the results list.</li>
<li><code>ResultItemVault</code> anchors the excerpt on <code>lazyMatches[0]?.offset</code>, so the excerpt falls on whichever loose index token the highlight regex happened to hit first. In practice that is a common word inside the frontmatter, near offset zero.</li>
</ol>
<p>Everything else in the path already folds case: <code>processTerm</code> lowercases at index and query time, the quoted-phrase filter compares two lowercased strings, and <code>stringsToRegex</code> compiles with the <code>i</code> flag. The correct file is retrieved, scored and would be highlighted correctly. Only the anchor is wrong, which makes a working search look like a failed one.</p>
<h2 data-heading="Fix">Fix</h2>
<pre><code class="language-diff">-      const best = text.indexOf(query.getBestStringForExcerpt())
+      const excerptString = query.getBestStringForExcerpt()
+      // Matched case-insensitively via regex rather than by lowercasing `text`,
+      // because toLowerCase() is not length-preserving across all of Unicode and
+      // would desynchronise `best` from the offsets collected above.
+      const best = text.search(new RegExp(escapeRegExp(excerptString), 'iu'))
       if (best > -1 &#x26;&#x26; matches.find(m => m.offset === best)) {
         matches.unshift({
           offset: best,
-          match: query.getBestStringForExcerpt(),
+          match: excerptString,
         })
       }
</code></pre>
<p><code>String.prototype.search</code> mirrors <code>indexOf</code>'s contract, returning the index of the first match or <code>-1</code>.</p>
<p>The obvious alternative, lowercasing both sides before the lookup, is not safe here. <code>toLowerCase()</code> is not length-preserving across all of Unicode. <code>U+0130</code> lowercases to two code units, so a note containing it would shift every subsequent index and desynchronise <code>best</code> from the offsets already collected by the <code>reg.exec(text)</code> loop above. A regex with the <code>i</code> flag folds case without altering the subject string, so indices stay exact.</p>
<p><code>escapeRegExp</code> is already imported in this file and already combined with the <code>u</code> flag in <code>stringsToRegex</code>, so the pattern has precedent here. es-toolkit's implementation escapes only <code>\ ^ $ . * + ? ( ) [ ] { } |</code>, none of which produce an illegal escape under <code>u</code>.</p>
<p>The <code>excerptString</code> local is needed for the regex, so reusing it for <code>match</code> also removes a second call to a getter that sorts <code>#inQuotes</code> in place.</p>
<h2 data-heading="Verification">Verification</h2>
<ul>
<li><code>pnpm run build</code> passes, including the <code>tsc -noEmit -skipLibCheck</code> gate.</li>
<li>Verified manually in Obsidian against a vault reproducing the case above. Match counts are now identical for lower-case, title-case and upper-case forms of the same quoted phrase, and all three anchor the excerpt on the phrase.</li>
<li>A quoted phrase containing regex metacharacters, for example <code>"maps keys (ADT) to values"</code>, does not throw.</li>
<li>A quoted phrase absent from a note still produces no anchor, so the change does not manufacture false positives.</li>
</ul>
<h2 data-heading="Out of scope">Out of scope</h2>
<ul>
<li>ESLint reports two errors and one warning in this file, at lines 92, 93 and 169. All three are pre-existing and outside the changed block, so they are left untouched to keep the diff reviewable.</li>
<li>Two Prettier deviations exist in this file, a trailing space in the JSDoc near line 14 and an over-wrapped <code>text.replace</code> call near line 46. Both are pre-existing. The changed block conforms to the repository's Prettier settings.</li>
<li>No automated test is included. <code>src/__tests__/query-tests.ts</code> and <code>src/__tests__/utils-tests.ts</code> currently fail on a clean checkout, because the <code>obsidian</code> package ships only type declarations with no runtime entry point and <code>jest-environment-jsdom</code> is not among the dev dependencies. Adding a test for this fix would require Jest configuration changes larger than the fix itself. A standalone reproduction harness can be supplied separately if that would be useful.</li>
</ul><!--EndFragment-->
</body>
</html>