### PR TITLE
fix: support Cmd+Click to open results in a new tab on macOS

### DIFF
--- a/src/components/ModalInFile.svelte
+++ b/src/components/ModalInFile.svelte
@@ -7,7 +7,7 @@
     type ResultNote,
     type SearchMatch,
   } from '../globals'
-  import { getCtrlKeyLabel, loopIndex } from '../tools/utils'
+  import { getCtrlKeyLabel, isModKeyPressed, loopIndex } from '../tools/utils'
   import { onDestroy, onMount, tick } from 'svelte'
   import { Platform } from 'obsidian'
   import ModalContainer from './ModalContainer.svelte'
@@ -128,9 +128,10 @@
   }
 
   async function openSelectionFromClick(evt: MouseEvent): Promise<void> {
+    const modKey = isModKeyPressed(evt)
     const newTab = plugin.settings.openInNewPane
-      ? !evt.ctrlKey
-      : evt.ctrlKey ? true : false
+      ? !modKey
+      : modKey ? true : false
     return openSelection(newTab)
   }
 

--- a/src/components/ModalVault.svelte
+++ b/src/components/ModalVault.svelte
@@ -17,6 +17,7 @@
     getAltKeyLabel,
     getExtension,
     isFilePDF,
+    isModKeyPressed,
     loopIndex,
   } from '../tools/utils'
   import {
@@ -167,9 +168,10 @@
 
   function onClick(evt?: MouseEvent | KeyboardEvent) {
     if (!selectedNote) return
+    const modKey = isModKeyPressed(evt)
     const newPane = plugin.settings.openInNewPane
-      ? !evt?.ctrlKey // Setting is true, ctrl not pressed => open in new pane
-      : evt?.ctrlKey ? true : false // Setting is false, ctrl pressed => open in same pane
+      ? !modKey // Setting is true, mod not pressed => open in new pane
+      : modKey ? true : false // Setting is false, mod pressed => open in same pane
     if (newPane) {
       openNoteInNewPane()
     } else {

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -152,6 +152,13 @@ export function getAltKeyLabel(): 'Alt' | '⌥' {
   return Platform.isMacOS ? '⌥' : 'Alt'
 }
 
+export function isModKeyPressed(
+  evt?: MouseEvent | KeyboardEvent | null
+): boolean {
+  if (!evt) return false
+  return Platform.isMacOS ? evt.metaKey : evt.ctrlKey
+}
+
 export function isFileImage(path: string): boolean {
   const ext = getExtension(path)
   return (


### PR DESCRIPTION
## Summary

Fixes #555.

On macOS, `Cmd+Click` on a search result did not open the note in a new
tab, even though `Cmd+Enter` does. The keyboard path works because it goes
through Obsidian's `Mod` modifier (Cmd on macOS, Ctrl elsewhere), but the
click handlers checked `evt.ctrlKey` directly. On macOS the "mod" key for a
mouse event is `metaKey`, not `ctrlKey`, so Cmd+Click was ignored and users
had to press Ctrl+Click instead.

## Changes

- Add an `isModKeyPressed()` helper in `src/tools/utils.ts` that returns
  `metaKey` on macOS and `ctrlKey` on other platforms, mirroring Obsidian's
  `Mod` behavior.
- Use it in the click handlers of both modals:
  - `ModalVault.svelte` → `onClick`
  - `ModalInFile.svelte` → `openSelectionFromClick`

This keeps Windows/Linux behavior unchanged (still Ctrl+Click) and makes
Cmd+Click on macOS consistent with Cmd+Enter.

## Testing

- `pnpm run build` passes (tsc clean).
- Verified on macOS: Cmd+Click now opens the result in a new tab, honoring
  the "Open in new pane" setting the same way Cmd+Enter does.
