### PR TITLE
perf: avoid retaining normalized document content

### DIFF
--- a/src/__tests__/utils-tests.ts
+++ b/src/__tests__/utils-tests.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { CachedMetadata } from 'obsidian'
-import { getAliasesFromMetadata, removeBase64Images } from '../tools/utils'
+import {
+  getAliasesFromMetadata,
+  normalizeExactMatchContent,
+  removeBase64Images,
+} from '../tools/utils'
 
 describe('Utils', () => {
   describe('getAliasesFromMetadata', () => {
@@ -98,6 +102,14 @@ describe('Utils', () => {
       const actual = removeBase64Images(text)
       // Assert
       expect(actual).toBe(text)
+    })
+  })
+
+  describe('normalizeExactMatchContent', () => {
+    it('matches the normalized content formerly retained by each document', () => {
+      expect(normalizeExactMatchContent('A *Crème* _brûlée_')).toBe(
+        'a creme brulee'
+      )
     })
   })
 })

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -57,7 +57,6 @@ export type IndexedDocument = {
   mtime: number
 
   content: string
-  cleanedContent: string
   aliases: string
   tags: string[]
   unmarkedTags: string[]

--- a/src/notes-indexer.ts
+++ b/src/notes-indexer.ts
@@ -121,7 +121,6 @@ export class NotesIndexer {
       mtime: 0,
 
       content: '',
-      cleanedContent: '',
       tags: [],
       unmarkedTags: [],
       aliases: '',

--- a/src/repositories/documents-repository.ts
+++ b/src/repositories/documents-repository.ts
@@ -14,8 +14,6 @@ import {
   isFileOffice,
   isFilePDF,
   logVerbose,
-  removeDiacritics,
-  stripMarkdownCharacters,
   warnVerbose,
 } from '../tools/utils'
 
@@ -239,8 +237,6 @@ export class DocumentsRepository {
       basename: file.basename,
       displayTitle,
       content,
-      /** Content without diacritics and markdown chars */
-      cleanedContent: stripMarkdownCharacters(removeDiacritics(content)),
       path: file.path,
       mtime: file.stat.mtime,
 

--- a/src/search/search-engine.ts
+++ b/src/search/search-engine.ts
@@ -14,6 +14,7 @@ import {
   chunkArray,
   countError,
   logVerbose,
+  normalizeExactMatchContent,
   removeDiacritics,
 } from '../tools/utils'
 import { Notice } from 'obsidian'
@@ -376,7 +377,7 @@ export class SearchEngine {
       results = results.filter(r => {
         const document = documents.find(d => d.path === r.id)
         const title = document?.path.toLowerCase() ?? ''
-        const content = (document?.cleanedContent ?? '').toLowerCase()
+        const content = normalizeExactMatchContent(document?.content ?? '')
         return exactTerms.every(
           q =>
             content.includes(q) ||

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -87,6 +87,10 @@ export function removeBase64Images(text: string): string {
   return text.replace(/data:[^;)]*;base64,[A-Za-z0-9+/=_-]*/g, '')
 }
 
+export function normalizeExactMatchContent(text: string): string {
+  return stripMarkdownCharacters(removeDiacritics(text)).toLowerCase()
+}
+
 export function getAliasesFromMetadata(
   metadata: CachedMetadata | null
 ): string[] {


### PR DESCRIPTION
Closes #578

`DocumentsRepository` currently retains both `content` and a normalized `cleanedContent` copy for every indexed document. The normalized copy is only used by quoted exact-term filtering, after results have already been sorted and limited to 50 candidates.

This PR drops the long-lived `cleanedContent` field and applies the identical normalization to the candidate document content only when an exact quoted query needs it. The MiniSearch index, tokenizer, ranking, and exact-match semantics are unchanged.

Validation:
- `pnpm test -- src/__tests__/utils-tests.ts` (23 tests)
- `pnpm build`

The build retains one pre-existing Svelte warning in `ModalVault.svelte` about `previousQuery` state capture.